### PR TITLE
Using `FnOnce` for state_fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,7 +701,7 @@ impl<EF: ExtraTokenFields, TT: TokenType, TE: ErrorResponseType> Client<EF, TT, 
     ///  instead.
     ///
     pub fn authorize_url<F>(&self, state_fn: F) -> (Url, CsrfToken)
-    where F: Fn() -> CsrfToken {
+    where F: FnOnce() -> CsrfToken {
         let state = state_fn();
         (self.authorize_url_impl("code", Some(&state), None), state)
     }
@@ -726,7 +726,7 @@ impl<EF: ExtraTokenFields, TT: TokenType, TE: ErrorResponseType> Client<EF, TT, 
     /// `insecure::authorize_url_implicit` instead.
     ///
     pub fn authorize_url_implicit<F>(&self, state_fn: F) -> (Url, CsrfToken)
-    where F: Fn() -> CsrfToken {
+    where F: FnOnce() -> CsrfToken {
         let state = state_fn();
         (self.authorize_url_impl("token", Some(&state), None), state)
     }


### PR DESCRIPTION
Making `state_fn` to be `FnOnce` callback, so it can pass ownership of state value (for example, if provided as `|| some_precreated_csrf`)

P.S. I think, it should also make it a little bit clearer that you are supposed to only used the value once.

So instead of:
```
let (auth_url, _) = cfg.authorize_url(|| state.clone() /* state is cloned! */);
```
one could do:
```
let (auth_url, _) = cfg.authorize_url(|| state /* state is moved in! */);
```