### PR TITLE
PKCE implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rand = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+sha2 = "0.7"
 url = "1.0"
 
 [dev-dependencies]

--- a/examples/msgraph.rs
+++ b/examples/msgraph.rs
@@ -1,0 +1,169 @@
+//!
+//! This example showcases the Microsoft Graph OAuth2 process for requesting access to Microsoft
+//! services using PKCE.
+//!
+//! Before running it, you'll need to generate your own Microsoft OAuth2 credentials.
+//!
+//! * Go to https://apps.dev.microsoft.com/
+//! * Click Add an App.
+//! * Skip the guided setup.
+//! * Set Web Redirect URL to http://localhost:3003/redirect
+//! * Add Delegated Permissions for Files.Read
+//! * Use the Application Id as MSGRAPH_CLIENT_ID.
+//! * Click Generate New Password.
+//! * Copy the password and use it as MSGRAPH_CLIENT_SECRET.
+//!
+//! In order to run the example call:
+//!
+//! ```sh
+//! MSGRAPH_CLIENT_ID=xxx MSGRAPH_CLIENT_SECRET=yyy cargo run --example msgraph
+//! ```
+//!
+//! ...and follow the instructions.
+//!
+
+extern crate base64;
+extern crate oauth2;
+extern crate rand;
+extern crate url;
+
+use oauth2::basic::BasicClient;
+use oauth2::prelude::*;
+use oauth2::{
+    AuthType, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CodeVerifierS256, CsrfToken,
+    RedirectUrl, ResponseType, Scope, TokenUrl
+};
+use std::env;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use url::Url;
+
+fn main() {
+    let graph_client_id = ClientId::new(
+        env::var("MSGRAPH_CLIENT_ID").expect("Missing the MSGRAPH_CLIENT_ID environment variable."),
+    );
+    let graph_client_secret = ClientSecret::new(
+        env::var("MSGRAPH_CLIENT_SECRET")
+            .expect("Missing the MSGRAPH_CLIENT_SECRET environment variable."),
+    );
+    let auth_url = AuthUrl::new(
+        Url::parse("https://login.microsoftonline.com/common/oauth2/v2.0/authorize")
+            .expect("Invalid authorization endpoint URL"),
+    );
+    let token_url = TokenUrl::new(
+        Url::parse("https://login.microsoftonline.com/common/oauth2/v2.0/token")
+            .expect("Invalid token endpoint URL"),
+    );
+
+    // Set up the config for the Microsoft Graph OAuth2 process.
+    let client = BasicClient::new(
+            graph_client_id,
+            Some(graph_client_secret),
+            auth_url,
+            Some(token_url)
+        )
+        // This example requests read access to OneDrive.
+        .add_scope(Scope::new("https://graph.microsoft.com/Files.Read".to_string()))
+
+        // Microsoft Graph requires client_id and client_secret in URL rather than
+        // using Basic authentication.
+        .set_auth_type(AuthType::RequestBody)
+
+        // This example will be running its own server at localhost:3003.
+        // See below for the server implementation.
+        .set_redirect_url(
+            RedirectUrl::new(
+                Url::parse("http://localhost:3003/redirect")
+                    .expect("Invalid redirect URL")
+            )
+        );
+
+    let csrf_state = CsrfToken::new_random();
+
+    // Microsoft Graph supports Proof Key for Code Exchange (PKCE - https://oauth.net/2/pkce/).
+    // Create a PKCE code verifier and SHA-256 encode it as a code challenge.
+    let code_verifier = CodeVerifierS256::new_random();
+    let code_challenge = code_verifier.code_challenge();
+
+    // Send the PKCE code challenge in the authorization request
+    let params: Vec<(&str, &str)> = vec![
+        ("state", csrf_state.secret()),
+        ("code_challenge_method", "S256"),
+        ("code_challenge", &code_challenge)
+    ];
+
+    // Generate the authorization URL to which we'll redirect the user.
+    let authorize_url
+        = client.authorize_url_extension(&ResponseType::new("code".to_string()), &params);
+
+    println!(
+        "Open this URL in your browser:\n{}\n",
+        authorize_url.to_string()
+    );
+
+    // A very naive implementation of the redirect server.
+    let listener = TcpListener::bind("127.0.0.1:3003").unwrap();
+    for stream in listener.incoming() {
+        if let Ok(mut stream) = stream {
+            let code;
+            let state;
+            {
+                let mut reader = BufReader::new(&stream);
+
+                let mut request_line = String::new();
+                reader.read_line(&mut request_line).unwrap();
+
+                let redirect_url = request_line.split_whitespace().nth(1).unwrap();
+                let url = Url::parse(&("http://localhost".to_string() + redirect_url)).unwrap();
+
+                let code_pair = url.query_pairs()
+                    .find(|pair| {
+                        let &(ref key, _) = pair;
+                        key == "code"
+                    })
+                    .unwrap();
+
+                let (_, value) = code_pair;
+                code = AuthorizationCode::new(value.into_owned());
+
+                let state_pair = url.query_pairs()
+                    .find(|pair| {
+                        let &(ref key, _) = pair;
+                        key == "state"
+                    })
+                    .unwrap();
+
+                let (_, value) = state_pair;
+                state = CsrfToken::new(value.into_owned());
+            }
+
+            let message = "Go back to your terminal :)";
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\n\r\n{}",
+                message.len(),
+                message
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+
+            println!("MS Graph returned the following code:\n{}\n", code.secret());
+            println!(
+                "MS Graph returned the following state:\n{} (expected `{}`)\n",
+                state.secret(),
+                csrf_state.secret()
+            );
+
+            // Send the PKCE code verifier in the token request
+            let params: Vec<(&str, &str)> = vec![
+                ("code_verifier", &code_verifier.secret())
+            ];
+
+            // Exchange the code with a token.
+            let token = client.exchange_code_extension(code, &params);
+
+            println!("MS Graph returned the following token:\n{:?}\n", token);
+
+            // The server will terminate itself after collecting the first code.
+            break;
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,6 +864,31 @@ impl<EF: ExtraTokenFields, TT: TokenType, TE: ErrorResponseType> Client<EF, TT, 
     }
 
     ///
+    /// Exchanges a code produced by a successful authorization process with an access token.
+    ///
+    /// Acquires ownership of the `code` because authorization codes may only be used to retrieve
+    /// an access token from the authorization server.
+    ///
+    /// See https://tools.ietf.org/html/rfc6749#section-4.1.3
+    ///
+    pub fn exchange_code_extension(
+        &self,
+        code: AuthorizationCode,
+        extra_params: &[(&str, &str)]
+    ) -> Result<TokenResponse<EF, TT>, RequestTokenError<TE>> {
+        // Make Clippy happy since we're intentionally taking ownership.
+        let code_owned = code;
+        let mut params = vec![
+            ("grant_type", "authorization_code"),
+            ("code", code_owned.secret())
+        ];
+
+        params.extend(extra_params.iter().cloned());
+
+        self.request_token(params)
+    }
+
+    ///
     /// Requests an access token for the *password* grant type.
     ///
     /// See https://tools.ietf.org/html/rfc6749#section-4.3.2

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -50,34 +50,36 @@ fn new_mock_client_with_unsafe_chars() -> BasicClient {
 #[test]
 #[should_panic]
 fn test_code_verifier_too_short() {
-    CodeVerifierS256::new_random_len(31);
+    PkceCodeVerifierS256::new_random_len(31);
 }
 
 #[test]
 #[should_panic]
 fn test_code_verifier_too_long() {
-    CodeVerifierS256::new_random_len(97);
+    PkceCodeVerifierS256::new_random_len(97);
 }
 
 #[test]
 fn test_code_verifier_min() {
-    let code_verifier = CodeVerifierS256::new_random_len(32);
+    let code_verifier = PkceCodeVerifierS256::new_random_len(32);
     assert!(code_verifier.secret().len() == 43);
 }
 
 #[test]
 fn test_code_verifier_max() {
-    let code_verifier = CodeVerifierS256::new_random_len(96);
+    let code_verifier = PkceCodeVerifierS256::new_random_len(96);
     assert!(code_verifier.secret().len() == 128);
 }
 
 #[test]
 fn test_code_verifier_challenge() {
     // Example from https://tools.ietf.org/html/rfc7636#appendix-B
-    let code_verifier = CodeVerifierS256::new(
+    let code_verifier = PkceCodeVerifierS256::new(
         "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".to_string()
     );
-    assert!(code_verifier.code_challenge() == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+    assert!(
+        code_verifier.code_challenge().as_str() == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    );
 }
 
 #[test]
@@ -124,18 +126,25 @@ fn test_authorize_url_insecure() {
 fn test_authorize_url_pkce() {
     // Example from https://tools.ietf.org/html/rfc7636#appendix-B
     let client = new_client();
-    let verifier = CodeVerifierS256::new("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".to_string());
+    let verifier =
+        PkceCodeVerifierS256::new("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".to_string());
     let challenge = verifier.code_challenge();
     let params = vec![
         ("code_challenge_method", "S256"),
         ("code_challenge", &challenge)
     ];
-    let url = client.authorize_url_extension(&ResponseType::new("code".to_string()), &params);
+    let (url, _) =
+        client.authorize_url_extension(
+            &ResponseType::new("code".to_string()),
+            || CsrfToken::new("csrf_token".to_string()),
+            &params
+        );
     assert_eq!(
         Url::parse(
             concat!(
                 "http://example.com/auth",
                 "?response_type=code&client_id=aaa",
+                "&state=csrf_token",
                 "&code_challenge_method=S256",
                 "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
             )
@@ -211,14 +220,17 @@ fn test_authorize_url_with_scopes() {
 fn test_authorize_url_with_extension_response_type() {
     let client = new_client();
 
-    let url = client.authorize_url_extension(
+    let (url, _) = client.authorize_url_extension(
         &ResponseType::new("code token".to_string()),
+        || CsrfToken::new("csrf_token".to_string()),
         &vec![("foo", "bar")],
     );
 
     assert_eq!(
-        Url::parse("http://example.com/auth?response_type=code+token&client_id=aaa&foo=bar")
-            .unwrap(),
+        Url::parse(
+            "http://example.com/auth?response_type=code+token&client_id=aaa&state=csrf_token\
+             &foo=bar"
+        ).unwrap(),
         url
     );
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -128,16 +128,11 @@ fn test_authorize_url_pkce() {
     let client = new_client();
     let verifier =
         PkceCodeVerifierS256::new("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".to_string());
-    let challenge = verifier.code_challenge();
-    let params = vec![
-        ("code_challenge_method", "S256"),
-        ("code_challenge", &challenge)
-    ];
     let (url, _) =
         client.authorize_url_extension(
             &ResponseType::new("code".to_string()),
             || CsrfToken::new("csrf_token".to_string()),
-            &params
+            &verifier.authorize_url_params(),
         );
     assert_eq!(
         Url::parse(

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -567,6 +567,50 @@ fn test_exchange_code_successful_with_basic_auth() {
 }
 
 #[test]
+fn test_exchange_code_successful_with_extension() {
+    let mock = mock("POST", "/token")
+        .match_header("Accept", "application/json")
+        .match_header("Authorization", "Basic YWFhOmJiYg==") // base64("aaa:bbb")
+        .match_body(
+            "grant_type=authorization_code&code=ccc\
+            &code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk\
+            &redirect_uri=http%3A%2F%2Fredirect%2Fhere"
+        )
+        .with_body(
+            "{\"access_token\": \"12/34\", \"token_type\": \"bearer\", \"scope\": \"read write\"}"
+        )
+        .create();
+
+    let client = new_mock_client()
+        .set_auth_type(oauth2::AuthType::BasicAuth)
+        .set_redirect_url(RedirectUrl::new(
+            Url::parse("http://redirect/here").unwrap(),
+        ));
+
+    let params: Vec<(&str, &str)> = vec![
+        ("code_verifier", "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+    ];
+
+    let token = client
+        .exchange_code_extension(AuthorizationCode::new("ccc".to_string()), &params)
+        .unwrap();
+
+    mock.assert();
+
+    assert_eq!("12/34", token.access_token().secret());
+    assert_eq!(BasicTokenType::Bearer, *token.token_type());
+    assert_eq!(
+        Some(&vec![
+            Scope::new("read".to_string()),
+            Scope::new("write".to_string()),
+        ]),
+        token.scopes()
+    );
+    assert_eq!(None, token.expires_in());
+    assert_eq!(None, token.refresh_token());
+}
+
+#[test]
 fn test_exchange_code_with_simple_json_error() {
     let mock = mock("POST", "/token")
         .match_header("Accept", "application/json")


### PR DESCRIPTION
Implementation of RFC 7636 Proof Key for Code Exchange by OAuth Public Clients.

To allow a client to be reused with unique PKCE codes, the `code_verifier` must be passed to new functions `authorize_url_pkce` and `exchange_code_pkce`.

The implementation only supports SHA256, the required default (and the most secure option).

I have also added an example of using PKCE with Microsoft Graph.