### PR TITLE
Include response for Parse errors

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -717,7 +717,7 @@ fn test_exchange_code_with_json_parse_error() {
     assert!(token.is_err());
 
     match token.err().unwrap() {
-        RequestTokenError::Parse(json_err) => {
+        RequestTokenError::Parse(json_err, _) => {
             assert_eq!(1, json_err.line());
             assert_eq!(1, json_err.column());
             assert_eq!(serde_json::error::Category::Syntax, json_err.classify());
@@ -780,7 +780,7 @@ fn test_exchange_code_with_invalid_token_type() {
 
     assert!(token.is_err());
     match token.err().unwrap() {
-        RequestTokenError::Parse(json_err) => {
+        RequestTokenError::Parse(json_err, _) => {
             assert_eq!(1, json_err.line());
             assert_eq!(48, json_err.column());
             assert_eq!(serde_json::error::Category::Data, json_err.classify());


### PR DESCRIPTION
I had a case where the server had a non-standard response, and not seeing that made it impossible to troubleshoot.

This includes the body that we attempted to parse in the `Parse` error variant directly, making it visible when formatting the error.