### PR TITLE
Support scope deserialization for non-compliant implementations

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -851,7 +851,8 @@ mod colorful_extension {
     use std::fmt::Error as FormatterError;
     use std::fmt::{Debug, Display, Formatter};
 
-    pub type ColorfulClient = Client<ColorfulFields, ColorfulTokenType, ColorfulErrorResponseType>;
+    pub type ColorfulClient =
+        Client<ColorfulFields, ColorfulTokenType, StringScopeField, ColorfulErrorResponseType>;
 
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     #[serde(rename_all = "lowercase")]
@@ -913,7 +914,8 @@ mod colorful_extension {
         }
     }
 
-    pub type ColorfulTokenResponse = TokenResponse<ColorfulFields, ColorfulTokenType>;
+    pub type ColorfulTokenResponse =
+        TokenResponse<ColorfulFields, ColorfulTokenType, StringScopeField>;
 }
 
 #[test]


### PR DESCRIPTION
I encountered this when trying to implement an authentication flow against Twitch.

You can see that [their documentation](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#oauth-authorization-code-flow) specifies the correct scope format (i.e. space-separated string), but in the example it responds with an array of strings. I've verified that this is also the case with the actual API.

I don't know if I'm doing something wrong, nor how proliferate these kind of implementations are. But from a pragmatic perspective it would be nice to be able to use `oauth2-rs` to get tokens from Twitch.

- [Topic raised on their dev forum (but unfortunately ignored)](https://discuss.dev.twitch.tv/t/wrong-return-type-of-scope-on-token-endpoint/15858)
- [Another one](https://discuss.dev.twitch.tv/t/docs-list-incorrect-type-for-oauth-scope-field/10427/3)