### PR TITLE
Client can parse non-standard Error Responses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ use std::time::Duration;
 use curl::easy::Easy;
 use rand::{thread_rng, Rng};
 use serde::de::DeserializeOwned;
-use serde::{Serialize};
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 use url::Url;
 
@@ -1418,9 +1418,11 @@ where
 ///
 /// Server Error Response
 ///
-/// See `StandardErrorResponse` for an implementation adhering to the oauth standard.
+/// This trait exists separately from the `StandardErrorResponse` struct
+/// to support customization by clients, such as supporting interoperability with
+/// non-standards-complaint OAuth2 providers
 ///
-pub trait ErrorResponse: DeserializeOwned + Serialize + Send + Sync + Debug + Display + 'static {}
+pub trait ErrorResponse: Debug + DeserializeOwned + Display + Send + Serialize + Sync {}
 
 ///
 /// Error types enum.
@@ -1529,7 +1531,7 @@ impl<TE: ErrorResponseType> Display for StandardErrorResponse<TE> {
 /// Error encountered while requesting access token.
 ///
 #[derive(Debug, Fail)]
-pub enum RequestTokenError<T: ErrorResponse> {
+pub enum RequestTokenError<T: ErrorResponse + 'static> {
     ///
     /// Error response returned by authorization server. Contains the parsed `ErrorResponse`
     /// returned by the server.
@@ -1567,7 +1569,7 @@ pub mod basic {
 
     use super::helpers;
     use super::{
-        Client, EmptyExtraTokenFields, StandardErrorResponse, ErrorResponseType, RequestTokenError,
+        Client, EmptyExtraTokenFields, ErrorResponseType, RequestTokenError, StandardErrorResponse,
         StandardTokenResponse, TokenType,
     };
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1148,13 +1148,12 @@ mod custom_errors {
 
     extern crate serde_json;
 
-    use oauth2::*;
     use colorful_extension::*;
-
+    use oauth2::*;
 
     #[derive(Serialize, Deserialize, Debug)]
     pub struct CustomErrorResponse {
-        pub custom_error: String
+        pub custom_error: String,
     }
 
     impl Display for CustomErrorResponse {
@@ -1183,9 +1182,7 @@ fn test_extension_with_custom_json_error() {
         .match_body("grant_type=authorization_code&code=ccc")
         .with_status(400)
         .with_header("content-type", "application/json")
-        .with_body(
-            "{\"custom_error\": \"non-compliant oauth implementation ;-)\"}",
-        )
+        .with_body("{\"custom_error\": \"non-compliant oauth implementation ;-)\"}")
         .create();
 
     let client = CustomErrorClient::new(
@@ -1204,8 +1201,10 @@ fn test_extension_with_custom_json_error() {
     assert!(token.is_err());
 
     match token.err().unwrap() {
-        RequestTokenError::ServerResponse(e) => assert_eq!("non-compliant oauth implementation ;-)", e.custom_error),
-        e => panic!("failed to correctly parse custom server error, got {:?}", e)
+        RequestTokenError::ServerResponse(e) => {
+            assert_eq!("non-compliant oauth implementation ;-)", e.custom_error)
+        }
+        e => panic!("failed to correctly parse custom server error, got {:?}", e),
     };
 }
 


### PR DESCRIPTION
ErrorResponse is now the trait that client takes.
The ErrorResponse struct has been renamed to StandardErrorResponse.
StandardErrorResponse's parameterization of ErroResponseType is it's own concern.