### PR TITLE
Make curl an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,18 @@ license = "MIT/Apache-2.0"
 description = "Bindings for exchanging OAuth 2 tokens"
 repository = "https://github.com/ramosbugs/oauth2-rs"
 
+[features]
+default = ["reqwest"]
+
 [dependencies]
 base64 = "0.9"
-curl = "0.4.0"
+curl = { version = "0.4.0", optional = true }
 failure = "0.1"
 failure_derive = "0.1"
 futures = "0.1"
 http = "0.1"
 rand = "0.6"
-reqwest = "0.9"
+reqwest = { version = "0.9", optional = true }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/examples/github.rs
+++ b/examples/github.rs
@@ -19,7 +19,8 @@ extern crate rand;
 extern crate url;
 
 use oauth2::basic::BasicClient;
-use oauth2::curl::http_client;
+// Alternatively, this can be `oauth2::curl::http_client` or a custom client.
+use oauth2::reqwest::http_client;
 use oauth2::{
     AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope,
     TokenResponse, TokenUrl,

--- a/examples/msgraph.rs
+++ b/examples/msgraph.rs
@@ -28,7 +28,8 @@ extern crate rand;
 extern crate url;
 
 use oauth2::basic::BasicClient;
-use oauth2::curl::http_client;
+// Alternatively, this can be `oauth2::curl::http_client` or a custom client.
+use oauth2::reqwest::http_client;
 use oauth2::{
     AuthType, AuthUrl, AuthorizationCode, ClientId, ClientSecret, CsrfToken, PkceCodeChallenge,
     RedirectUrl, Scope, TokenUrl,

--- a/examples/wunderlist.rs
+++ b/examples/wunderlist.rs
@@ -22,7 +22,8 @@ extern crate serde;
 
 use oauth2::TokenType;
 use oauth2::basic::{ BasicErrorResponse, BasicTokenType };
-use oauth2::curl::http_client;
+// Alternatively, this can be `oauth2::curl::http_client` or a custom client.
+use oauth2::reqwest::http_client;
 use oauth2::helpers;
 use oauth2::{
     AccessToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,11 +321,13 @@
 //!
 
 extern crate base64;
+#[cfg(feature = "curl")]
 extern crate curl as curl_;
 extern crate failure;
 extern crate futures;
 extern crate http;
 extern crate rand;
+#[cfg(feature = "reqwest")]
 extern crate reqwest as reqwest_;
 extern crate serde;
 #[macro_use]
@@ -358,6 +360,7 @@ pub mod basic;
 ///
 /// HTTP client backed by the [curl](https://crates.io/crates/curl) crate.
 ///
+#[cfg(feature = "curl")]
 pub mod curl;
 
 ///
@@ -368,6 +371,7 @@ pub mod helpers;
 ///
 /// HTTP client backed by the [reqwest](https://crates.io/crates/reqwest) crate.
 ///
+#[cfg(feature = "reqwest")]
 pub mod reqwest;
 
 #[cfg(test)]


### PR DESCRIPTION
Make reqwest the default http backend.

Discussed in [#44](https://github.com/ramosbugs/oauth2-rs/issues/44#issuecomment-501591680).