### PR TITLE
bind reqwest 0.9 to http 0.1 and reqwest 0.10 to http 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["reqwest-09"]
+default = []
 futures-01 = ["futures-0-1"]
 futures-03 = ["futures-0-3", "async-trait"]
-reqwest-09 = ["reqwest-0-9"]
-reqwest-010 = ["reqwest-0-10"]
+reqwest-09 = ["reqwest-0-9", "http-0-1"]
+reqwest-010 = ["reqwest-0-10", "http-0-2"]
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
@@ -29,10 +29,11 @@ failure = "0.1"
 failure_derive = "0.1"
 futures-0-1 = { version = "0.1", optional = true, package = "futures" }
 futures-0-3 = { version = "0.3", optional = true, package = "futures" }
-http = "0.1"
+http-0-1 = { version = "0.1", optional = true, package = "http" }
+http-0-2 = { version = "0.2", optional = true, package = "http" }
 rand = "0.6"
 reqwest-0-9 = { version = "0.9", optional = true, package = "reqwest" }
-reqwest-0-10 = { version = "=0.10.0-alpha.2", optional = true, features = ["blocking"], package = "reqwest" }
+reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking"], package = "reqwest" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,8 +488,14 @@ use std::time::Duration;
 use failure::Fail;
 #[cfg(feature = "futures-01")]
 use futures_0_1::{Future, IntoFuture};
+
+#[cfg(feature = "reqwest-09")]
+pub use http_0_1 as http;
+#[cfg(feature = "reqwest-010")]
+pub use http_0_2 as http;
 use http::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use http::status::StatusCode;
+
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use url::{form_urlencoded, Url};
@@ -528,10 +534,6 @@ mod tests;
 
 mod types;
 
-///
-/// Public re-exports of types used for HTTP client interfaces.
-///
-pub use http;
 pub use url;
 
 pub use types::{

--- a/src/reqwest/async_client.rs
+++ b/src/reqwest/async_client.rs
@@ -11,7 +11,7 @@ pub async fn async_http_client(
 ) -> Result<HttpResponse, Error<reqwest::Error>> {
     let client = reqwest::Client::builder()
         // Following redirects opens the client up to SSRF vulnerabilities.
-        .redirect(reqwest::RedirectPolicy::none())
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(Error::Reqwest)?;
 

--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -1,4 +1,5 @@
 use failure::Fail;
+use super::http;
 
 ///
 /// Error type returned by failed reqwest HTTP requests.
@@ -63,7 +64,7 @@ mod blocking {
     #[cfg(feature = "reqwest-010")]
     use reqwest_0_10::blocking;
     #[cfg(feature = "reqwest-010")]
-    use reqwest_0_10::RedirectPolicy;
+    use reqwest_0_10::redirect::Policy as RedirectPolicy;
 
     use std::io::Read;
 


### PR DESCRIPTION
This is an alternative solution for #79 :

- reqwest-09 requires http 0.1 (and http 0.1 is exported as http)
- reqwest-010 requires http 0.2 (and http 0.2 is exported as http)

Also the default feature was turned off, as 
 - it would require reqwest-010 feature would require a no-default
 - request is "just" a sample client implementation and on could provide his/her implementation if required.