### PR TITLE
Make http 0.1 optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["reqwest-09"]
-futures-01 = ["futures-0-1"]
+futures-01 = ["futures-0-1", "http-0-1"]
 futures-03 = ["futures-0-3", "async-trait"]
 reqwest-09 = ["reqwest-0-9", "http-0-1"]
 reqwest-010 = ["reqwest-0-10", "http-0-2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "actively-developed" }
 default = ["reqwest-09"]
 futures-01 = ["futures-0-1"]
 futures-03 = ["futures-0-3", "async-trait"]
-reqwest-09 = ["reqwest-0-9"]
+reqwest-09 = ["reqwest-0-9", "http-0-1"]
 reqwest-010 = ["reqwest-0-10", "http-0-2"]
 
 [dependencies]
@@ -29,7 +29,7 @@ failure = "0.1"
 failure_derive = "0.1"
 futures-0-1 = { version = "0.1", optional = true, package = "futures" }
 futures-0-3 = { version = "0.3", optional = true, package = "futures" }
-http = "0.1"
+http-0-1 = { version = "0.1", optional = true, package = "http" }
 http-0-2 = { version = "0.2", optional = true, package = "http" }
 rand = "0.6"
 reqwest-0-9 = { version = "0.9", optional = true, package = "reqwest" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["reqwest-09"]
 futures-01 = ["futures-0-1", "http-0-1"]
-futures-03 = ["futures-0-3", "async-trait"]
+futures-03 = ["futures-0-3", "async-trait", "http-0-2"]
 reqwest-09 = ["reqwest-0-9", "http-0-1"]
 reqwest-010 = ["reqwest-0-10", "http-0-2"]
 

--- a/examples/letterboxd.rs
+++ b/examples/letterboxd.rs
@@ -16,7 +16,8 @@
 use crypto::{hmac, mac::Mac, sha2};
 use hex::ToHex;
 use oauth2::{
-    basic::BasicClient, AuthType, AuthUrl, ClientId, ClientSecret, HttpRequest, HttpResponse,
+    basic::BasicClient, http::method::Method,
+    AuthType, AuthUrl, ClientId, ClientSecret, HttpRequest, HttpResponse,
     ResourceOwnerPassword, ResourceOwnerUsername, TokenUrl,
 };
 use url::Url;
@@ -102,7 +103,7 @@ impl SigningHttpClient {
     /// query.
     ///
     /// See http://api-docs.letterboxd.com/#signing.
-    fn sign_url(&self, mut url: Url, method: &http::method::Method, body: &[u8]) -> Url {
+    fn sign_url(&self, mut url: Url, method: &Method, body: &[u8]) -> Url {
         let nonce = uuid::Uuid::new_v4(); // use UUID as random and unique nonce
 
         let timestamp = time::SystemTime::now()

--- a/src/curl.rs
+++ b/src/curl.rs
@@ -2,9 +2,13 @@ use std::io::Read;
 
 use curl::easy::Easy;
 use failure::Fail;
-use http::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
-use http::method::Method;
-use http::status::StatusCode;
+#[cfg(any(feature = "http-0-1", feature = "http-0-2"))]
+use super::http::{
+    self as http,
+    header::{HeaderMap, HeaderValue, CONTENT_TYPE},
+    method::Method,
+    status::StatusCode,
+};
 
 use super::{HttpRequest, HttpResponse};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,7 +493,7 @@ use http_0_1::{
     header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE},
     status::StatusCode,
 };
-#[cfg(feature = "http-0-2")]
+#[cfg(all(feature = "http-0-2", not(feature = "http-0-1")))]
 use http_0_2::{
     header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE},
     status::StatusCode,
@@ -541,7 +541,7 @@ mod types;
 ///
 #[cfg(feature = "http-0-1")]
 pub use http_0_1 as http;
-#[cfg(feature = "http-0-2")]
+#[cfg(all(feature = "http-0-2", not(feature = "http-0-1")))]
 pub use http_0_2 as http;
 pub use url;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,8 +488,16 @@ use std::time::Duration;
 use failure::Fail;
 #[cfg(feature = "futures-01")]
 use futures_0_1::{Future, IntoFuture};
-use http::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
-use http::status::StatusCode;
+#[cfg(feature = "http-0-1")]
+use http_0_1::{
+    header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE},
+    status::StatusCode,
+};
+#[cfg(feature = "http-0-2")]
+use http_0_2::{
+    header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE},
+    status::StatusCode,
+};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use url::{form_urlencoded, Url};
@@ -531,7 +539,10 @@ mod types;
 ///
 /// Public re-exports of types used for HTTP client interfaces.
 ///
-pub use http;
+#[cfg(feature = "http-0-1")]
+pub use http_0_1 as http;
+#[cfg(feature = "http-0-2")]
+pub use http_0_2 as http;
 pub use url;
 
 pub use types::{

--- a/src/reqwest/async_client.rs
+++ b/src/reqwest/async_client.rs
@@ -1,8 +1,8 @@
 use super::super::{HttpRequest, HttpResponse};
 use super::Error;
 
-use http::header::HeaderName;
-use http::{HeaderMap, HeaderValue, StatusCode};
+use super::super::http::header::HeaderName;
+use super::super::http::{HeaderMap, HeaderValue, StatusCode};
 
 pub use reqwest_0_10 as reqwest;
 

--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -1,9 +1,7 @@
 use failure::Fail;
 
-#[cfg(feature = "http-0-1")]
-use http_0_1 as http;
-#[cfg(feature = "http-0-2")]
-use http_0_2 as http;
+#[cfg(any(feature = "http-0-1", feature = "http-0-2"))]
+use super::http;
 
 ///
 /// Error type returned by failed reqwest HTTP requests.
@@ -115,20 +113,21 @@ mod blocking {
         }
         #[cfg(feature = "reqwest-010")]
         {
+            use super::super::http::{header::HeaderName, HeaderValue, HeaderMap, StatusCode};
             let headers = response
                 .headers()
                 .iter()
                 .map(|(name, value)| {
                     (
-                        http_0_2::header::HeaderName::from_bytes(name.as_str().as_ref())
+                        HeaderName::from_bytes(name.as_str().as_ref())
                             .expect("failed to convert HeaderName from http 0.2 to 0.1"),
-                        http_0_2::HeaderValue::from_bytes(value.as_bytes())
+                        HeaderValue::from_bytes(value.as_bytes())
                             .expect("failed to convert HeaderValue from http 0.2 to 0.1"),
                     )
                 })
-                .collect::<http_0_2::HeaderMap>();
+                .collect::<HeaderMap>();
             Ok(HttpResponse {
-                status_code: http_0_2::StatusCode::from_u16(response.status().as_u16())
+                status_code: StatusCode::from_u16(response.status().as_u16())
                     .expect("failed to convert StatusCode from http 0.2 to 0.1"),
                 headers,
                 body,

--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -1,5 +1,10 @@
 use failure::Fail;
 
+#[cfg(feature = "http-0-1")]
+use http_0_1 as http;
+#[cfg(feature = "http-0-2")]
+use http_0_2 as http;
+
 ///
 /// Error type returned by failed reqwest HTTP requests.
 ///
@@ -115,15 +120,15 @@ mod blocking {
                 .iter()
                 .map(|(name, value)| {
                     (
-                        http::header::HeaderName::from_bytes(name.as_str().as_ref())
+                        http_0_2::header::HeaderName::from_bytes(name.as_str().as_ref())
                             .expect("failed to convert HeaderName from http 0.2 to 0.1"),
-                        http::HeaderValue::from_bytes(value.as_bytes())
+                        http_0_2::HeaderValue::from_bytes(value.as_bytes())
                             .expect("failed to convert HeaderValue from http 0.2 to 0.1"),
                     )
                 })
-                .collect::<http::HeaderMap>();
+                .collect::<http_0_2::HeaderMap>();
             Ok(HttpResponse {
-                status_code: http::StatusCode::from_u16(response.status().as_u16())
+                status_code: http_0_2::StatusCode::from_u16(response.status().as_u16())
                     .expect("failed to convert StatusCode from http 0.2 to 0.1"),
                 headers,
                 body,


### PR DESCRIPTION
Hi @ramosbugs , thanks for your work on oauth2 and openidconnect in rust!

Here's a suggestion for some dependency cleanup (related to ramosbugs/openidconnect-rs#8):

Make the http 0.1 dependency optional and enable it for reqwest 0.9. Reexport the enabled http version as oauth::http (rather than exporting http 0.1 even if using reqwest 0.10, which uses http 0.2).

Addendum:  I just found #82, which is rather similar to this, but perhaps the timing is better now that reqwest 0.10 is actually released?

Or maybe support for reqwest 0.9, futures 0.1 and http 0.1 should just be dropped before oauth2 3.0 is actually released?  That would simplify things quite a bit, but it may be a bit premature?