### PR TITLE
Replace deprecated "failure" with "thiserror" and "anyhow"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ reqwest-010 = ["reqwest-0-10", "http-0-2"]
 async-trait = { version = "0.1", optional = true }
 base64 = "0.10"
 curl = { version = "0.4.0", optional = true }
-failure = "0.1"
-failure_derive = "0.1"
+thiserror="1.0.16"
 futures-0-1 = { version = "0.1", optional = true, package = "futures" }
 futures-0-3 = { version = "0.3", optional = true, package = "futures" }
 http = "0.1"
@@ -46,3 +45,4 @@ hex = "=0.4.0"
 rust-crypto = "0.2.36"
 tokio = "0.1"
 uuid = { version = "0.8.1", features = ["v4"] }
+anyhow="1.0.28"

--- a/examples/letterboxd.rs
+++ b/examples/letterboxd.rs
@@ -24,7 +24,7 @@ use url::Url;
 use std::env;
 use std::time;
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), anyhow::Error> {
     // a.k.a api key in Letterboxd API documentation
     let letterboxd_client_id = ClientId::new(
         env::var("LETTERBOXD_CLIENT_ID")
@@ -89,7 +89,7 @@ impl SigningHttpClient {
     }
 
     /// Signs the request before calling `oauth2::reqwest::http_client`.
-    fn execute(&self, mut request: HttpRequest) -> Result<HttpResponse, impl failure::Fail> {
+    fn execute(&self, mut request: HttpRequest) -> Result<HttpResponse, impl std::error::Error> {
         let signed_url = self.sign_url(request.url, &request.method, &request.body);
         request.url = signed_url;
         oauth2::reqwest::http_client(request)

--- a/src/async_internal.rs
+++ b/src/async_internal.rs
@@ -4,7 +4,7 @@ use crate::{
     TokenType,
 };
 use async_trait::async_trait;
-use failure::Fail;
+use std::error::Error;
 use futures_0_3::Future;
 
 ///
@@ -24,7 +24,7 @@ where
     where
         C: FnOnce(HttpRequest) -> F + Send,
         F: Future<Output = Result<HttpResponse, RE>> + Send,
-        RE: Fail;
+        RE: Error + Send + Sync + 'static;
 }
 
 #[async_trait]
@@ -41,7 +41,7 @@ where
     where
         C: FnOnce(HttpRequest) -> F + Send,
         F: Future<Output = Result<HttpResponse, RE>> + Send,
-        RE: Fail,
+        RE: Error + Send + Sync + 'static,
     {
         let http_request = self.prepare_request()?;
         let http_response = http_client(http_request)
@@ -68,7 +68,7 @@ where
     where
         C: FnOnce(HttpRequest) -> F + Send,
         F: Future<Output = Result<HttpResponse, RE>> + Send,
-        RE: Fail;
+        RE: Error + Send + Sync + 'static;
 }
 
 #[async_trait]
@@ -85,7 +85,7 @@ where
     where
         C: FnOnce(HttpRequest) -> F + Send,
         F: Future<Output = Result<HttpResponse, RE>> + Send,
-        RE: Fail,
+        RE: Error + Send + Sync + 'static,
     {
         let http_request = self.prepare_request()?;
         let http_response = http_client(http_request)
@@ -112,7 +112,7 @@ where
     where
         C: FnOnce(HttpRequest) -> F + Send,
         F: Future<Output = Result<HttpResponse, RE>> + Send,
-        RE: Fail;
+        RE: Error + Send + Sync + 'static;
 }
 
 #[async_trait]
@@ -129,7 +129,7 @@ where
     where
         C: FnOnce(HttpRequest) -> F + Send,
         F: Future<Output = Result<HttpResponse, RE>> + Send,
-        RE: Fail,
+        RE: Error + Send + Sync + 'static,
     {
         let http_request = self.prepare_request()?;
         let http_response = http_client(http_request)
@@ -156,7 +156,7 @@ where
     where
         C: FnOnce(HttpRequest) -> F + Send,
         F: Future<Output = Result<HttpResponse, RE>> + Send,
-        RE: Fail;
+        RE: Error + Send + Sync + 'static;
 }
 
 #[async_trait]
@@ -174,7 +174,7 @@ where
     where
         C: FnOnce(HttpRequest) -> F + Send,
         F: Future<Output = Result<HttpResponse, RE>> + Send,
-        RE: Fail,
+        RE: Error + Send + Sync + 'static,
     {
         let http_request = self.prepare_request()?;
         let http_response = http_client(http_request)

--- a/src/curl.rs
+++ b/src/curl.rs
@@ -1,7 +1,6 @@
 use std::io::Read;
 
 use curl::easy::Easy;
-use failure::Fail;
 use http::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use http::method::Method;
 use http::status::StatusCode;
@@ -11,16 +10,16 @@ use super::{HttpRequest, HttpResponse};
 ///
 /// Error type returned by failed curl HTTP requests.
 ///
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error returned by curl crate.
-    #[fail(display = "curl request failed")]
-    Curl(#[cause] curl::Error),
+    #[error("curl request failed")]
+    Curl(#[source] curl::Error),
     /// Non-curl HTTP error.
-    #[fail(display = "HTTP error")]
-    Http(#[cause] http::Error),
+    #[error("HTTP error")]
+    Http(#[source] http::Error),
     /// Other error.
-    #[fail(display = "Other error: {}", _0)]
+    #[error("Other error: {}", _0)]
     Other(String),
 }
 

--- a/src/reqwest/mod.rs
+++ b/src/reqwest/mod.rs
@@ -1,24 +1,24 @@
-use failure::Fail;
+use thiserror::Error;
 
 ///
 /// Error type returned by failed reqwest HTTP requests.
 ///
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum Error<T>
 where
     T: std::error::Error + Send + Sync + 'static,
 {
     /// Error returned by reqwest crate.
-    #[fail(display = "request failed")]
-    Reqwest(#[cause] T),
+    #[error("request failed")]
+    Reqwest(#[source] T),
     /// Non-reqwest HTTP error.
-    #[fail(display = "HTTP error")]
-    Http(#[cause] http::Error),
+    #[error("HTTP error")]
+    Http(#[source] http::Error),
     /// I/O error.
-    #[fail(display = "I/O error")]
-    Io(#[cause] std::io::Error),
+    #[error("I/O error")]
+    Io(#[source] std::io::Error),
     /// Other error.
-    #[fail(display = "Other error: {}", _0)]
+    #[error("Other error: {}", _0)]
     Other(String),
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use failure::Fail;
+use thiserror::Error;
 use http::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use http::status::StatusCode;
 use url::form_urlencoded::byte_serialize;
@@ -229,9 +229,9 @@ fn test_authorize_url_with_redirect_url() {
     );
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 enum FakeError {
-    #[fail(display = "error")]
+    #[error("error")]
     Err,
 }
 


### PR DESCRIPTION
The `failure` crate was deprecated recently, so this PR removes it
in favor of `thiserror`.