### PR TITLE
Allows switching between native-tls and rustls-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["reqwest-09"]
+default = ["reqwest-09-native"]
 futures-01 = ["futures-0-1"]
 futures-03 = ["futures-0-3", "async-trait"]
-reqwest-09 = ["reqwest-0-9"]
-reqwest-010 = ["reqwest-0-10", "http-0-2"]
+reqwest-09-native = ["reqwest-0-9", "reqwest-0-9/default-tls"]
+reqwest-09-rustls = ["reqwest-0-9", "reqwest-0-9/rustls-tls"]
+reqwest-010-native = ["reqwest-0-10", "http-0-2", "reqwest-0-10/default-tls"]
+reqwest-010-rustls = ["reqwest-0-10", "http-0-2", "reqwest-0-10/rustls-tls"]
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
@@ -33,7 +35,7 @@ http = "0.1"
 http-0-2 = { version = "0.2", optional = true, package = "http" }
 rand = "0.6"
 reqwest-0-9 = { version = "0.9", optional = true, package = "reqwest" }
-reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking"], package = "reqwest" }
+reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking"], package = "reqwest", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.7"


### PR DESCRIPTION
It would be awesome if one is able to switch between native and rustls. This is a first idea of how to archive that. 

Another idea would be to introduce the flags `native-tls` and `rustls-tls` similar to reqwest but those would always add both dependencies. 

Any thoughts on this? I would like to change this in [openidconnect-rs](https://github.com/ramosbugs/openidconnect-rs) too once we find a good solution