### PR TITLE
Updating to sha2 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ reqwest-0-9 = { version = "0.9", optional = true, package = "reqwest" }
 reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking"], package = "reqwest" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = "0.7"
+sha2 = "0.8"
 # To support rustc < 1.36
 unicode-normalization = "=0.1.9"
 url = "2.1"


### PR DESCRIPTION
sha2 got updated to v0.8. Updating works without any compile issues so there are no api changes

Update:
Sha2 is used only in letterboxd.rs and types.rs. Both do not use it in a user facing api.

The most notable change that happend in the sha2 crate is the update of digest to 0.8 and block-buffer to 0.7. They had to change their user facing api but not the parts this crate is using.