### PR TITLE
Updating to rand 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures-0-1 = { version = "0.1", optional = true, package = "futures" }
 futures-0-3 = { version = "0.3", optional = true, package = "futures" }
 http = "0.1"
 http-0-2 = { version = "0.2", optional = true, package = "http" }
-rand = "0.6"
+rand = "0.7"
 reqwest-0-9 = { version = "0.9", optional = true, package = "reqwest" }
 reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking"], package = "reqwest" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Another simple update. This time its the `rand` crate.

Changes:
https://github.com/rust-random/rand/compare/0.6.5...0.7.3
I had a quick look at the changes and it does not seem like it would affect this crate. A lot of restructuring mostly due to the switch to v2018.

Usage:
* [types.rs#L6](https://github.com/ramosbugs/oauth2-rs/blob/master/src/types.rs#L6)
* [types.rs#L437](https://github.com/ramosbugs/oauth2-rs/blob/master/src/types.rs#L437)
* [types.rs#L516](https://github.com/ramosbugs/oauth2-rs/blob/master/src/types.rs#L516)

which contains csrf and oauth code handling. It does not contain user facing api. 

Sorry for the noise if you would prefer me to squash updates into one PR instead of making dozens I'm happy to do that instead. 
