### PR TITLE
Add ability to override the authorization url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,7 +679,7 @@ where
             client_id: &self.client_id,
             extra_params: Vec::new(),
             pkce_challenge: None,
-            redirect_url: self.redirect_url.as_ref(),
+            redirect_url: self.redirect_url.as_ref().map(Cow::Borrowed),
             response_type: "code".into(),
             scopes: Vec::new(),
             state: state_fn(),
@@ -785,7 +785,7 @@ pub struct AuthorizationRequest<'a> {
     client_id: &'a ClientId,
     extra_params: Vec<(Cow<'a, str>, Cow<'a, str>)>,
     pkce_challenge: Option<PkceCodeChallenge>,
-    redirect_url: Option<&'a RedirectUrl>,
+    redirect_url: Option<Cow<'a, RedirectUrl>>,
     response_type: Cow<'a, str>,
     scopes: Vec<Cow<'a, Scope>>,
     state: CsrfToken,
@@ -849,6 +849,14 @@ impl<'a> AuthorizationRequest<'a> {
     ///
     pub fn set_pkce_challenge(mut self, pkce_code_challenge: PkceCodeChallenge) -> Self {
         self.pkce_challenge = Some(pkce_code_challenge);
+        self
+    }
+
+    ///
+    /// Overrides the `redirect_url` to the one specified.
+    ///
+    pub fn set_redirect_url(mut self, redirect_url: Cow<'a, RedirectUrl>) -> Self {
+        self.redirect_url = Some(redirect_url);
         self
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -229,6 +229,28 @@ fn test_authorize_url_with_redirect_url() {
     );
 }
 
+#[test]
+fn test_authorize_url_with_redirect_url_override() {
+    let client = new_client()
+        .set_redirect_url(RedirectUrl::new("https://localhost/redirect".to_string()).unwrap());
+
+    let (url, _) = client
+        .authorize_url(|| CsrfToken::new("csrf_token".to_string()))
+        .set_redirect_url(Cow::Owned(RedirectUrl::new("https://localhost/alternative".to_string()).unwrap()))
+        .url();
+
+    assert_eq!(
+        Url::parse(
+            "https://example.com/auth?response_type=code\
+             &client_id=aaa\
+             &state=csrf_token\
+             &redirect_uri=https%3A%2F%2Flocalhost%2Falternative"
+        )
+        .unwrap(),
+        url
+    );
+}
+
 #[derive(Debug, Fail)]
 enum FakeError {
     #[fail(display = "error")]


### PR DESCRIPTION
Adds method and test to override `redirect_url` on authorization.

Ref: ramosbugs/openidconnect-rs/issues/18