### PR TITLE
Updating to base64 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ reqwest-010 = ["reqwest-0-10", "http-0-2"]
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
-base64 = "0.10"
+base64 = "0.12"
 curl = { version = "0.4.0", optional = true }
 failure = "0.1"
 failure_derive = "0.1"


### PR DESCRIPTION
Hopefully the last update in this crate for a bit.

Changes:
https://github.com/marshallpierce/rust-base64/compare/v0.10.1...v0.12.1
The commits show that its mostly new stuff, modularization and the switch to no_std
