### PR TITLE
Updating to sha2 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ reqwest-0-9 = { version = "0.9", optional = true, package = "reqwest" }
 reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking"], package = "reqwest" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = "0.8"
+sha2 = "0.9"
 # To support rustc < 1.36
 unicode-normalization = "=0.1.9"
 url = "2.1"


### PR DESCRIPTION
Another easy update. I have, however, a few more things I would like to do:

* Update to 1.36 as min (its now a year old and would allow us to update unicode-normalization)
* Switch http1 and http2. Currently we have to use http1 to implement our own http clients. Switching would allow us to use http2. It means making http optional and http-0-2 the default. Of course it does introduce quite some changes to the user api.

Any chance those would get merged if I create PRs?