### PR TITLE
Switching reqwest to rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror="1.0"
 futures-0-3 = { version = "0.3", optional = true, package = "futures" }
 http = "0.2"
 rand = "0.7"
-reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking"], package = "reqwest" }
+reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking", "rustls-tls"], package = "reqwest", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"


### PR DESCRIPTION
I think with this one in, we may release the first alpha version so that we are able to continue on openidconnect-rs. 

Alternatively we may thing about releasing as there are no more api updates expected and #97 and #105 would only add new stuff (minor version bump)

Edit: before releasing we may want to take a closer look at #80. Because if we do decide to remove async_trait it would introduce a breaking change