### PR TITLE
Enable Serde for re-exported Url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking", "rus
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"
-url = "2.1"
+url = { version = "2.1", features = ["serde"] }
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
I'm not sure if this is needed, but I was using the re-exported `url::Url` and expected it to have serde support. I figured I would open this in case it made sense to add. Cheers!