### PR TITLE
Add derive(Eq, PartialEq) to CsrfToken

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -496,7 +496,7 @@ new_secret_type![
     /// via the `state` parameter.
     ///
     #[must_use]
-    #[derive(Clone, Deserialize, Serialize)]
+    #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
     CsrfToken(String)
     impl {
         ///


### PR DESCRIPTION
I find myself wanting to compare `state == expected_state` with them both being a `CsrfToken`. Do you think it makes sense to derive Eq and PartialEq for this type?