### PR TITLE
WIP: Add initial support for Device Code Flow as per RFC 8628

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"
 url = { version = "2.1", features = ["serde"] }
+async-std = "1.6.3"
 
 [dev-dependencies]
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"
 url = { version = "2.1", features = ["serde"] }
-async-std = "1.6.3"
 
 [dev-dependencies]
 hex = "0.4"
@@ -37,3 +36,4 @@ hmac = "0.8"
 uuid = { version = "0.8", features = ["v4"] }
 anyhow="1.0"
 tokio = { version = "0.2", features = ["full"] }
+async-std = "1.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"
 url = { version = "2.1", features = ["serde"] }
+chrono = "0.4"
 
 [dev-dependencies]
 hex = "0.4"

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -40,10 +40,10 @@ fn main() {
     // Google's OAuth endpoint expects the client_id to be in the request body,
     // so ensure that option is set.
     let device_client = BasicClient::new(
-        google_client_id.clone(),
-        Some(google_client_secret.clone()),
-        auth_url.clone(),
-        Some(token_url.clone()),
+        google_client_id,
+        Some(google_client_secret),
+        auth_url,
+        Some(token_url),
     )
     .set_device_authorization_url(device_auth_url)
     .set_auth_type(AuthType::RequestBody);
@@ -63,16 +63,10 @@ fn main() {
     );
 
     // Now poll for the token
-    let token = BasicClient::new(
-        google_client_id,
-        Some(google_client_secret),
-        auth_url,
-        Some(token_url),
-    )
-    .set_device_authorization_details(details)
-    .exchange_device_access_token()
-    .request(http_client, std::thread::sleep)
-    .expect("Failed to get token");
+    let token = device_client
+        .exchange_device_access_token(&details)
+        .request(http_client, std::thread::sleep)
+        .expect("Failed to get token");
 
     println!("Google returned the following token:\n{:?}\n", token);
 }

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -16,7 +16,7 @@
 use oauth2::basic::BasicClient;
 // Alternatively, this can be oauth2::curl::http_client or a custom.
 use oauth2::reqwest::http_client;
-use oauth2::{AuthUrl, ClientId, ClientSecret, DeviceAuthorizationUrl, Scope, TokenUrl};
+use oauth2::{AuthType, AuthUrl, ClientId, ClientSecret, DeviceAuthorizationUrl, Scope, TokenUrl};
 use std::env;
 
 fn main() {
@@ -36,13 +36,17 @@ fn main() {
             .expect("Invalid device authorization endpoint URL");
 
     // Set up the config for the Google OAuth2 process.
+    //
+    // Google's OAuth endpoint expects the client_id to be in the request body,
+    // so ensure that option is set.
     let device_client = BasicClient::new(
         google_client_id.clone(),
         Some(google_client_secret.clone()),
         auth_url.clone(),
         Some(token_url.clone()),
     )
-    .set_device_authorization_url(device_auth_url);
+    .set_device_authorization_url(device_auth_url)
+    .set_auth_type(AuthType::RequestBody);
 
     // Request the set of codes from the Device Authorization endpoint.
     let details = device_client

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -1,0 +1,74 @@
+//!
+//! This example showcases the Google OAuth2 process for requesting access to the Google Calendar features
+//! and the user's profile.
+//!
+//! Before running it, you'll need to generate your own Google OAuth2 credentials.
+//!
+//! In order to run the example call:
+//!
+//! ```sh
+//! GOOGLE_CLIENT_ID=xxx GOOGLE_CLIENT_SECRET=yyy cargo run --example google
+//! ```
+//!
+//! ...and follow the instructions.
+//!
+
+use oauth2::basic::BasicClient;
+// Alternatively, this can be oauth2::curl::http_client or a custom.
+use oauth2::reqwest::http_client;
+use oauth2::{AuthUrl, ClientId, ClientSecret, DeviceAuthorizationUrl, Scope, TokenUrl};
+use std::env;
+
+fn main() {
+    let google_client_id = ClientId::new(
+        env::var("GOOGLE_CLIENT_ID").expect("Missing the GOOGLE_CLIENT_ID environment variable."),
+    );
+    let google_client_secret = ClientSecret::new(
+        env::var("GOOGLE_CLIENT_SECRET")
+            .expect("Missing the GOOGLE_CLIENT_SECRET environment variable."),
+    );
+    let auth_url = AuthUrl::new("https://accounts.google.com/o/oauth2/v2/auth".to_string())
+        .expect("Invalid authorization endpoint URL");
+    let token_url = TokenUrl::new("https://www.googleapis.com/oauth2/v3/token".to_string())
+        .expect("Invalid token endpoint URL");
+    let device_auth_url =
+        DeviceAuthorizationUrl::new("https://oauth2.googleapis.com/device/code".to_string())
+            .expect("Invalid device authorization endpoint URL");
+
+    // Set up the config for the Google OAuth2 process.
+    let device_client = BasicClient::new(
+        google_client_id.clone(),
+        Some(google_client_secret.clone()),
+        auth_url.clone(),
+        Some(token_url.clone()),
+    )
+    .set_device_authorization_url(device_auth_url);
+
+    // Request the set of codes from the Device Authorization endpoint.
+    let details = device_client
+        .exchange_device_code()
+        .add_scope(Scope::new("profile".to_string()))
+        .request(http_client)
+        .expect("Failed to request codes from device auth endpoint");
+
+    // Display the URL and user-code.
+    println!(
+        "Open this URL in your browser:\n{}\nand enter the code: {}",
+        details.verification_uri().to_string(),
+        details.user_code().to_string()
+    );
+
+    // Now poll for the token
+    let token = BasicClient::new(
+        google_client_id,
+        Some(google_client_secret),
+        auth_url,
+        Some(token_url),
+    )
+    .set_device_authorization_details(details)
+    .exchange_device_access_token()
+    .request(http_client)
+    .expect("Failed to get token");
+
+    println!("Google returned the following token:\n{:?}\n", token);
+}

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -15,12 +15,12 @@
 
 use oauth2::basic::BasicClient;
 // Alternatively, this can be oauth2::curl::http_client or a custom.
+use oauth2::devicecode::{DeviceAuthorizationResponse, ExtraDeviceAuthorizationFields};
 use oauth2::reqwest::http_client;
 use oauth2::{AuthType, AuthUrl, ClientId, ClientSecret, DeviceAuthorizationUrl, Scope, TokenUrl};
-use oauth2::devicecode::{DeviceAuthorizationResponse, ExtraDeviceAuthorizationFields};
-use std::env;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use serde::{Serialize, Deserialize};
+use std::env;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct StoringFields(HashMap<String, serde_json::Value>);

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -17,7 +17,16 @@ use oauth2::basic::BasicClient;
 // Alternatively, this can be oauth2::curl::http_client or a custom.
 use oauth2::reqwest::http_client;
 use oauth2::{AuthType, AuthUrl, ClientId, ClientSecret, DeviceAuthorizationUrl, Scope, TokenUrl};
+use oauth2::devicecode::{DeviceAuthorizationResponse, ExtraDeviceAuthorizationFields};
 use std::env;
+use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StoringFields(HashMap<String, serde_json::Value>);
+
+impl ExtraDeviceAuthorizationFields for StoringFields {}
+type StoringDeviceAuthorizationResponse = DeviceAuthorizationResponse<StoringFields>;
 
 fn main() {
     let google_client_id = ClientId::new(
@@ -49,7 +58,7 @@ fn main() {
     .set_auth_type(AuthType::RequestBody);
 
     // Request the set of codes from the Device Authorization endpoint.
-    let details = device_client
+    let details: StoringDeviceAuthorizationResponse = device_client
         .exchange_device_code()
         .add_scope(Scope::new("profile".to_string()))
         .request(http_client)

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -59,7 +59,7 @@ fn main() {
     println!(
         "Open this URL in your browser:\n{}\nand enter the code: {}",
         details.verification_uri().to_string(),
-        details.user_code().to_string()
+        details.user_code().secret().to_string()
     );
 
     // Now poll for the token

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -67,7 +67,7 @@ fn main() {
     )
     .set_device_authorization_details(details)
     .exchange_device_access_token()
-    .request(http_client)
+    .request(http_client, std::thread::sleep)
     .expect("Failed to get token");
 
     println!("Google returned the following token:\n{:?}\n", token);

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -65,7 +65,7 @@ fn main() {
     // Now poll for the token
     let token = device_client
         .exchange_device_access_token(&details)
-        .request(http_client, std::thread::sleep)
+        .request(http_client, std::thread::sleep, None)
         .expect("Failed to get token");
 
     println!("Google returned the following token:\n{:?}\n", token);

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -117,7 +117,7 @@ pub enum BasicErrorResponseType {
     Extension(String),
 }
 impl BasicErrorResponseType {
-    fn from_str(s: &str) -> Self {
+    pub(crate) fn from_str(s: &str) -> Self {
         match s {
             "invalid_client" => BasicErrorResponseType::InvalidClient,
             "invalid_grant" => BasicErrorResponseType::InvalidGrant,

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -1,0 +1,276 @@
+use std::fmt::Error as FormatterError;
+use std::fmt::{Debug, Display, Formatter};
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use super::{ErrorResponseType, StandardErrorResponse, DeviceCode, UserCode, EndUserVerificationUrl, };
+
+/// The minimum amount of time in seconds that the client SHOULD wait
+/// between polling requests to the token endpoint.  If no value is
+/// provided, clients MUST use 5 as the default.
+fn default_devicecode_interval() -> u64 {
+    5
+}
+
+///
+/// Standard OAuth2 device authorization response.
+///
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DeviceAuthorizationDetails {
+    /// The device verification code.
+    device_code: DeviceCode,
+
+    /// The end-user verification code.
+    user_code: UserCode,
+
+    /// The end-user verification URI on the authorization The URI should be
+    /// short and easy to remember as end users will be asked to manually type
+    /// it into their user agent.
+    #[serde(alias = "verification_url")]
+    verification_uri: EndUserVerificationUrl,
+
+    /// A verification URI that includes the "user_code" (or other information
+    /// with the same function as the "user_code"), which is designed for
+    /// non-textual transmission.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verification_uri_complete: Option<EndUserVerificationUrl>,
+
+    /// The lifetime in seconds of the "device_code" and "user_code".
+    expires_in: u64,
+
+    /// The minimum amount of time in seconds that the client SHOULD wait
+    /// between polling requests to the token endpoint.  If no value is
+    /// provided, clients MUST use 5 as the default.
+    #[serde(default = "default_devicecode_interval")]
+    interval: u64,
+
+    #[serde(flatten)]
+    extra_fields: HashMap<String, serde_json::Value>,
+}
+
+impl DeviceAuthorizationDetails {
+    /// The device verification code.
+    pub fn device_code(&self) -> &DeviceCode {
+        return &self.device_code;
+    }
+
+    /// The end-user verification code.
+    pub fn user_code(&self) -> &UserCode {
+        return &self.user_code;
+    }
+
+    /// The end-user verification URI on the authorization The URI should be
+    /// short and easy to remember as end users will be asked to manually type
+    /// it into their user agent.
+    pub fn verification_uri(&self) -> &EndUserVerificationUrl {
+        return &self.verification_uri;
+    }
+
+    /// A verification URI that includes the "user_code" (or other information
+    /// with the same function as the "user_code"), which is designed for
+    /// non-textual transmission.
+    pub fn verification_uri_complete(&self) -> Option<&EndUserVerificationUrl> {
+        return self.verification_uri_complete.as_ref();
+    }
+
+    /// The lifetime in seconds of the "device_code" and "user_code".
+    pub fn expires_in(&self) -> Duration {
+        return Duration::from_secs(self.expires_in);
+    }
+
+    /// The minimum amount of time in seconds that the client SHOULD wait
+    /// between polling requests to the token endpoint.  If no value is
+    /// provided, clients MUST use 5 as the default.
+    pub fn interval(&self) -> Duration {
+        return Duration::from_secs(self.interval);
+    }
+
+    /// Any extra fields that were added to the response.
+    pub fn extra_fields(&self) -> &HashMap<String, serde_json::Value> {
+        return &self.extra_fields;
+    }
+}
+
+///
+/// The action that the device code flow should currently be taking.
+///
+#[derive(Debug, thiserror::Error)]
+pub enum DeviceCodeAction<T: Debug> {
+    ///
+    /// Retry the current request, waiting for the current interval value.
+    ///
+    #[error("Request failed, retry after waiting")]
+    Retry,
+    ///
+    /// Increase the interval by 5 seconds as per
+    /// https://tools.ietf.org/html/rfc8628#section-3.5, then retry the current
+    /// request.
+    ///
+    #[error("Request failed, increase interval then retry after waiting")]
+    IncreaseIntervalThenRetry,
+    ///
+    /// Double the interval to back off the server on a failure, then retry the
+    /// current request.
+    ///
+    #[error("Request failed, double interval then retry after waiting")]
+    DoubleIntervalThenRetry,
+    ///
+    /// Do not do any more requests.
+    ///
+    #[error("Request failed")]
+    NoFurtherRequests(T),
+}
+
+///
+/// Basic access token error types.
+///
+/// These error types are defined in
+/// [Section 5.2 of RFC 6749](https://tools.ietf.org/html/rfc6749#section-5.2) and
+/// [Section 3.5 of RFC 6749](https://tools.ietf.org/html/rfc8628#section-3.5)
+///
+#[derive(Clone, PartialEq)]
+pub enum DeviceCodeErrorResponseType {
+    ///
+    /// The authorization request is still pending as the end user hasn't
+    /// yet completed the user-interaction steps.  The client SHOULD repeat the
+    /// access token request to the token endpoint.  Before each new request,
+    /// the client MUST wait at least the number of seconds specified by the
+    /// "interval" parameter of the device authorization response, or 5 seconds
+    /// if none was provided, and respect any increase in the polling interval
+    /// required by the "slow_down" error.
+    ///
+    AuthorizationPending,
+    ///
+    /// A variant of "authorization_pending", the authorization request is
+    /// still pending and polling should continue, but the interval MUST be
+    /// increased by 5 seconds for this and all subsequent requests.
+    SlowDown,
+    ///
+    /// The authorization request was denied.
+    ///
+    AccessDenied,
+    ///
+    /// The "device_code" has expired, and the device authorization session has
+    /// concluded.  The client MAY commence a new device authorization request
+    /// but SHOULD wait for user interaction before restarting to avoid
+    /// unnecessary polling.
+    ExpiredToken,
+    ///
+    /// Client authentication failed (e.g., unknown client, no client authentication included,
+    /// or unsupported authentication method).
+    ///
+    InvalidClient,
+    ///
+    /// The provided authorization grant (e.g., authorization code, resource owner credentials)
+    /// or refresh token is invalid, expired, revoked, does not match the redirection URI used
+    /// in the authorization request, or was issued to another client.
+    ///
+    InvalidGrant,
+    ///
+    /// The request is missing a required parameter, includes an unsupported parameter value
+    /// (other than grant type), repeats a parameter, includes multiple credentials, utilizes
+    /// more than one mechanism for authenticating the client, or is otherwise malformed.
+    ///
+    InvalidRequest,
+    ///
+    /// The requested scope is invalid, unknown, malformed, or exceeds the scope granted by the
+    /// resource owner.
+    ///
+    InvalidScope,
+    ///
+    /// The authenticated client is not authorized to use this authorization grant type.
+    ///
+    UnauthorizedClient,
+    ///
+    /// The authorization grant type is not supported by the authorization server.
+    ///
+    UnsupportedGrantType,
+    ///
+    /// An extension not defined by RFC 6749 or RFC 8628
+    ///
+    Extension(String),
+}
+impl DeviceCodeErrorResponseType {
+    fn from_str(s: &str) -> Self {
+        match s {
+            "authorization_pending" => DeviceCodeErrorResponseType::AuthorizationPending,
+            "slow_down" => DeviceCodeErrorResponseType::SlowDown,
+            "access_denied" => DeviceCodeErrorResponseType::AccessDenied,
+            "expired_token" => DeviceCodeErrorResponseType::ExpiredToken,
+            "invalid_client" => DeviceCodeErrorResponseType::InvalidClient,
+            "invalid_grant" => DeviceCodeErrorResponseType::InvalidGrant,
+            "invalid_request" => DeviceCodeErrorResponseType::InvalidRequest,
+            "invalid_scope" => DeviceCodeErrorResponseType::InvalidScope,
+            "unauthorized_client" => DeviceCodeErrorResponseType::UnauthorizedClient,
+            "unsupported_grant_type" => DeviceCodeErrorResponseType::UnsupportedGrantType,
+            ext => DeviceCodeErrorResponseType::Extension(ext.to_string()),
+        }
+    }
+}
+impl AsRef<str> for DeviceCodeErrorResponseType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            DeviceCodeErrorResponseType::AuthorizationPending => "authorization_pending",
+            DeviceCodeErrorResponseType::SlowDown => "slow_down",
+            DeviceCodeErrorResponseType::AccessDenied => "access_denied",
+            DeviceCodeErrorResponseType::ExpiredToken => "expired_token",
+            DeviceCodeErrorResponseType::InvalidClient => "invalid_client",
+            DeviceCodeErrorResponseType::InvalidGrant => "invalid_grant",
+            DeviceCodeErrorResponseType::InvalidRequest => "invalid_request",
+            DeviceCodeErrorResponseType::InvalidScope => "invalid_scope",
+            DeviceCodeErrorResponseType::UnauthorizedClient => "unauthorized_client",
+            DeviceCodeErrorResponseType::UnsupportedGrantType => "unsupported_grant_type",
+            DeviceCodeErrorResponseType::Extension(ref ext) => ext.as_str(),
+        }
+    }
+}
+impl<'de> serde::Deserialize<'de> for DeviceCodeErrorResponseType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let variant_str = String::deserialize(deserializer)?;
+        Ok(Self::from_str(&variant_str))
+    }
+}
+impl serde::ser::Serialize for DeviceCodeErrorResponseType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_str(self.as_ref())
+    }
+}
+impl ErrorResponseType for DeviceCodeErrorResponseType {}
+impl Debug for DeviceCodeErrorResponseType {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatterError> {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for DeviceCodeErrorResponseType {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatterError> {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+///
+/// Error response specialization for device code OAuth2 implementation.
+///
+pub type DeviceCodeErrorResponse = StandardErrorResponse<DeviceCodeErrorResponseType>;
+
+impl DeviceCodeErrorResponse {
+    ///
+    /// Convert a device code error response to the next action that should
+    /// be taken.
+    ///
+    pub fn to_action<T: Debug>(&self, req: T) -> DeviceCodeAction<T> {
+        match &self.error {
+            DeviceCodeErrorResponseType::AuthorizationPending => DeviceCodeAction::Retry,
+            DeviceCodeErrorResponseType::SlowDown => DeviceCodeAction::IncreaseIntervalThenRetry,
+            _ => DeviceCodeAction::NoFurtherRequests(req),
+        }
+    }
+}

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -114,6 +114,11 @@ where
     pub fn interval(&self) -> Duration {
         Duration::from_secs(self.interval)
     }
+
+    /// Any extra fields returned on the response.
+    pub fn extra_fields(&self) -> &EF {
+        &self.extra_fields
+    }
 }
 
 ///

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -32,6 +32,9 @@ pub struct DeviceAuthorizationResponse {
     /// The end-user verification URI on the authorization The URI should be
     /// short and easy to remember as end users will be asked to manually type
     /// it into their user agent.
+    ///
+    /// The `verification_url` alias here is a deviation from the RFC, as
+    /// implementations of device code flow predate RFC 8628.
     #[serde(alias = "verification_url")]
     verification_uri: EndUserVerificationUrl,
 

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -20,7 +20,7 @@ fn default_devicecode_interval() -> u64 {
 /// Standard OAuth2 device authorization response.
 ///
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DeviceAuthorizationDetails {
+pub struct DeviceAuthorizationResponse {
     /// The device verification code.
     device_code: DeviceCode,
 
@@ -52,7 +52,7 @@ pub struct DeviceAuthorizationDetails {
     extra_fields: HashMap<String, serde_json::Value>,
 }
 
-impl DeviceAuthorizationDetails {
+impl DeviceAuthorizationResponse {
     /// The device verification code.
     pub fn device_code(&self) -> &DeviceCode {
         return &self.device_code;

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -2,8 +2,8 @@ use std::fmt::Error as FormatterError;
 use std::fmt::{Debug, Display, Formatter};
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
 use super::{
     DeviceCode, EndUserVerificationUrl, ErrorResponseType, StandardErrorResponse, UserCode,
@@ -27,7 +27,7 @@ pub trait ExtraDeviceAuthorizationFields: DeserializeOwned + Debug + Serialize {
 ///
 /// Empty (default) extra token fields.
 ///
-pub struct EmptyExtraDeviceAuthorizationFields{}
+pub struct EmptyExtraDeviceAuthorizationFields {}
 impl ExtraDeviceAuthorizationFields for EmptyExtraDeviceAuthorizationFields {}
 
 ///
@@ -36,7 +36,7 @@ impl ExtraDeviceAuthorizationFields for EmptyExtraDeviceAuthorizationFields {}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DeviceAuthorizationResponse<EF>
 where
-    EF: ExtraDeviceAuthorizationFields
+    EF: ExtraDeviceAuthorizationFields,
 {
     /// The device verification code.
     device_code: DeviceCode,
@@ -74,7 +74,7 @@ where
 
 impl<EF> DeviceAuthorizationResponse<EF>
 where
-    EF: ExtraDeviceAuthorizationFields
+    EF: ExtraDeviceAuthorizationFields,
 {
     /// The device verification code.
     pub fn device_code(&self) -> &DeviceCode {
@@ -117,7 +117,8 @@ where
 /// Standard implementation of DeviceAuthorizationResponse which throws away
 /// extra received response fields.
 ///
-pub type StandardDeviceAuthorizationResponse = DeviceAuthorizationResponse<EmptyExtraDeviceAuthorizationFields>;
+pub type StandardDeviceAuthorizationResponse =
+    DeviceAuthorizationResponse<EmptyExtraDeviceAuthorizationFields>;
 
 ///
 /// The action that the device code flow should currently be taking.

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -5,10 +5,10 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
+use super::basic::BasicErrorResponseType;
 use super::{
     DeviceCode, EndUserVerificationUrl, ErrorResponseType, StandardErrorResponse, UserCode,
 };
-use super::basic::BasicErrorResponseType;
 
 /// The minimum amount of time in seconds that the client SHOULD wait
 /// between polling requests to the token endpoint.  If no value is
@@ -174,7 +174,7 @@ impl DeviceCodeErrorResponseType {
                 "access_denied" => DeviceCodeErrorResponseType::AccessDenied,
                 "expired_token" => DeviceCodeErrorResponseType::ExpiredToken,
                 _ => DeviceCodeErrorResponseType::Basic(BasicErrorResponseType::Extension(ext)),
-            }
+            },
             basic => DeviceCodeErrorResponseType::Basic(basic),
         }
     }

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -81,38 +81,38 @@ where
 {
     /// The device verification code.
     pub fn device_code(&self) -> &DeviceCode {
-        return &self.device_code;
+        &self.device_code
     }
 
     /// The end-user verification code.
     pub fn user_code(&self) -> &UserCode {
-        return &self.user_code;
+        &self.user_code
     }
 
     /// The end-user verification URI on the authorization The URI should be
     /// short and easy to remember as end users will be asked to manually type
     /// it into their user agent.
     pub fn verification_uri(&self) -> &EndUserVerificationUrl {
-        return &self.verification_uri;
+        &self.verification_uri
     }
 
     /// A verification URI that includes the "user_code" (or other information
     /// with the same function as the "user_code"), which is designed for
     /// non-textual transmission.
     pub fn verification_uri_complete(&self) -> Option<&VerificationUriComplete> {
-        return self.verification_uri_complete.as_ref();
+        self.verification_uri_complete.as_ref()
     }
 
     /// The lifetime in seconds of the "device_code" and "user_code".
     pub fn expires_in(&self) -> Duration {
-        return Duration::from_secs(self.expires_in);
+        Duration::from_secs(self.expires_in)
     }
 
     /// The minimum amount of time in seconds that the client SHOULD wait
     /// between polling requests to the token endpoint.  If no value is
     /// provided, clients MUST use 5 as the default.
     pub fn interval(&self) -> Duration {
-        return Duration::from_secs(self.interval);
+        Duration::from_secs(self.interval)
     }
 }
 

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     DeviceCode, EndUserVerificationUrl, ErrorResponseType, StandardErrorResponse, UserCode,
 };
+use super::basic::BasicErrorResponseType;
 
 /// The minimum amount of time in seconds that the client SHOULD wait
 /// between polling requests to the token endpoint.  If no value is
@@ -160,71 +161,32 @@ pub enum DeviceCodeErrorResponseType {
     /// unnecessary polling.
     ExpiredToken,
     ///
-    /// Client authentication failed (e.g., unknown client, no client authentication included,
-    /// or unsupported authentication method).
+    /// A Basic response type
     ///
-    InvalidClient,
-    ///
-    /// The provided authorization grant (e.g., authorization code, resource owner credentials)
-    /// or refresh token is invalid, expired, revoked, does not match the redirection URI used
-    /// in the authorization request, or was issued to another client.
-    ///
-    InvalidGrant,
-    ///
-    /// The request is missing a required parameter, includes an unsupported parameter value
-    /// (other than grant type), repeats a parameter, includes multiple credentials, utilizes
-    /// more than one mechanism for authenticating the client, or is otherwise malformed.
-    ///
-    InvalidRequest,
-    ///
-    /// The requested scope is invalid, unknown, malformed, or exceeds the scope granted by the
-    /// resource owner.
-    ///
-    InvalidScope,
-    ///
-    /// The authenticated client is not authorized to use this authorization grant type.
-    ///
-    UnauthorizedClient,
-    ///
-    /// The authorization grant type is not supported by the authorization server.
-    ///
-    UnsupportedGrantType,
-    ///
-    /// An extension not defined by RFC 6749 or RFC 8628
-    ///
-    Extension(String),
+    Basic(BasicErrorResponseType),
 }
 impl DeviceCodeErrorResponseType {
     fn from_str(s: &str) -> Self {
-        match s {
-            "authorization_pending" => DeviceCodeErrorResponseType::AuthorizationPending,
-            "slow_down" => DeviceCodeErrorResponseType::SlowDown,
-            "access_denied" => DeviceCodeErrorResponseType::AccessDenied,
-            "expired_token" => DeviceCodeErrorResponseType::ExpiredToken,
-            "invalid_client" => DeviceCodeErrorResponseType::InvalidClient,
-            "invalid_grant" => DeviceCodeErrorResponseType::InvalidGrant,
-            "invalid_request" => DeviceCodeErrorResponseType::InvalidRequest,
-            "invalid_scope" => DeviceCodeErrorResponseType::InvalidScope,
-            "unauthorized_client" => DeviceCodeErrorResponseType::UnauthorizedClient,
-            "unsupported_grant_type" => DeviceCodeErrorResponseType::UnsupportedGrantType,
-            ext => DeviceCodeErrorResponseType::Extension(ext.to_string()),
+        match BasicErrorResponseType::from_str(s) {
+            BasicErrorResponseType::Extension(ext) => match ext.as_str() {
+                "authorization_pending" => DeviceCodeErrorResponseType::AuthorizationPending,
+                "slow_down" => DeviceCodeErrorResponseType::SlowDown,
+                "access_denied" => DeviceCodeErrorResponseType::AccessDenied,
+                "expired_token" => DeviceCodeErrorResponseType::ExpiredToken,
+                _ => DeviceCodeErrorResponseType::Basic(BasicErrorResponseType::Extension(ext)),
+            }
+            basic => DeviceCodeErrorResponseType::Basic(basic),
         }
     }
 }
 impl AsRef<str> for DeviceCodeErrorResponseType {
     fn as_ref(&self) -> &str {
-        match *self {
+        match self {
             DeviceCodeErrorResponseType::AuthorizationPending => "authorization_pending",
             DeviceCodeErrorResponseType::SlowDown => "slow_down",
             DeviceCodeErrorResponseType::AccessDenied => "access_denied",
             DeviceCodeErrorResponseType::ExpiredToken => "expired_token",
-            DeviceCodeErrorResponseType::InvalidClient => "invalid_client",
-            DeviceCodeErrorResponseType::InvalidGrant => "invalid_grant",
-            DeviceCodeErrorResponseType::InvalidRequest => "invalid_request",
-            DeviceCodeErrorResponseType::InvalidScope => "invalid_scope",
-            DeviceCodeErrorResponseType::UnauthorizedClient => "unauthorized_client",
-            DeviceCodeErrorResponseType::UnsupportedGrantType => "unsupported_grant_type",
-            DeviceCodeErrorResponseType::Extension(ref ext) => ext.as_str(),
+            DeviceCodeErrorResponseType::Basic(basic) => basic.as_ref(),
         }
     }
 }

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -5,10 +5,11 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use super::basic::BasicErrorResponseType;
 use super::{
     DeviceCode, EndUserVerificationUrl, ErrorResponseType, StandardErrorResponse, UserCode,
 };
+use crate::basic::BasicErrorResponseType;
+use crate::types::VerificationUriComplete;
 
 /// The minimum amount of time in seconds that the client SHOULD wait
 /// between polling requests to the token endpoint.  If no value is
@@ -38,7 +39,7 @@ pub struct DeviceAuthorizationResponse {
     /// with the same function as the "user_code"), which is designed for
     /// non-textual transmission.
     #[serde(skip_serializing_if = "Option::is_none")]
-    verification_uri_complete: Option<EndUserVerificationUrl>,
+    verification_uri_complete: Option<VerificationUriComplete>,
 
     /// The lifetime in seconds of the "device_code" and "user_code".
     expires_in: u64,
@@ -74,7 +75,7 @@ impl DeviceAuthorizationResponse {
     /// A verification URI that includes the "user_code" (or other information
     /// with the same function as the "user_code"), which is designed for
     /// non-textual transmission.
-    pub fn verification_uri_complete(&self) -> Option<&EndUserVerificationUrl> {
+    pub fn verification_uri_complete(&self) -> Option<&VerificationUriComplete> {
         return self.verification_uri_complete.as_ref();
     }
 

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -227,36 +227,6 @@ impl Display for DeviceCodeErrorResponseType {
 ///
 pub type DeviceCodeErrorResponse = StandardErrorResponse<DeviceCodeErrorResponseType>;
 
-pub(crate) struct DeviceAccessResult<TR, RE, TE, TT>
-where
-    TE: ErrorResponse + 'static,
-    TR: TokenResponse<TT>,
-    TT: TokenType,
-    RE: Error + 'static,
-{
-    res: Result<TR, RequestTokenError<RE, TE>>,
-    _phantom: PhantomData<TT>,
-}
-
-impl<TR, RE, TE, TT> DeviceAccessResult<TR, RE, TE, TT>
-where
-    TE: ErrorResponse + 'static,
-    TR: TokenResponse<TT>,
-    TT: TokenType,
-    RE: Error + 'static,
-{
-    pub fn new(res: Result<TR, RequestTokenError<RE, TE>>) -> Self {
-        Self {
-            res,
-            _phantom: PhantomData,
-        }
-    }
-
-    pub fn result(self) -> Result<TR, RequestTokenError<RE, TE>> {
-        self.res
-    }
-}
-
 pub(crate) enum DeviceAccessTokenPollResult<TR, RE, TE, TT>
 where
     TE: ErrorResponse + 'static,
@@ -265,5 +235,5 @@ where
     RE: Error + 'static,
 {
     ContinueWithNewPollInterval(Duration),
-    Done(DeviceAccessResult<TR, RE, TE, TT>),
+    Done(Result<TR, RequestTokenError<RE, TE>>, PhantomData<TT>),
 }

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -101,7 +101,7 @@ impl DeviceAuthorizationResponse {
 /// The action that the device code flow should currently be taking.
 ///
 #[derive(Debug, thiserror::Error)]
-pub enum DeviceCodeAction<T: Debug> {
+pub(crate) enum DeviceCodeAction<T: Debug> {
     ///
     /// Retry the current request, waiting for the current interval value.
     ///
@@ -231,7 +231,7 @@ impl DeviceCodeErrorResponse {
     /// Convert a device code error response to the next action that should
     /// be taken.
     ///
-    pub fn to_action<T: Debug>(&self, req: T) -> DeviceCodeAction<T> {
+    pub(crate) fn to_action<T: Debug>(&self, req: T) -> DeviceCodeAction<T> {
         match &self.error {
             DeviceCodeErrorResponseType::AuthorizationPending => DeviceCodeAction::Retry,
             DeviceCodeErrorResponseType::SlowDown => DeviceCodeAction::IncreaseIntervalThenRetry,

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -1,11 +1,13 @@
+use std::collections::HashMap;
 use std::fmt::Error as FormatterError;
 use std::fmt::{Debug, Display, Formatter};
-use std::collections::HashMap;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use super::{ErrorResponseType, StandardErrorResponse, DeviceCode, UserCode, EndUserVerificationUrl, };
+use super::{
+    DeviceCode, EndUserVerificationUrl, ErrorResponseType, StandardErrorResponse, UserCode,
+};
 
 /// The minimum amount of time in seconds that the client SHOULD wait
 /// between polling requests to the token endpoint.  If no value is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,7 +754,6 @@ where
             client_secret: self.client_secret.as_ref(),
             extra_params: Vec::new(),
             scopes: Vec::new(),
-            token_url: self.token_url.as_ref(),
             device_authorization_url: self.device_authorization_url.as_ref(),
             _phantom: PhantomData,
         }
@@ -1560,7 +1559,6 @@ where
     client_secret: Option<&'a ClientSecret>,
     extra_params: Vec<(Cow<'a, str>, Cow<'a, str>)>,
     scopes: Vec<Cow<'a, Scope>>,
-    token_url: Option<&'a TokenUrl>,
     device_authorization_url: Option<&'a DeviceAuthorizationUrl>,
     _phantom: PhantomData<TE>,
 }
@@ -1606,7 +1604,7 @@ where
         RE: Error + 'static,
     {
         Ok(endpoint_request(
-            &AuthType::RequestBody,
+            self.auth_type,
             self.client_id,
             None,
             &self.extra_params,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1021,7 +1021,8 @@ where
             self.redirect_url,
             None,
             self.token_url
-                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?,
+                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?
+                .url(),
             params,
         ))
     }
@@ -1161,7 +1162,8 @@ where
             None,
             Some(&self.scopes),
             self.token_url
-                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?,
+                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?
+                .url(),
             vec![
                 ("grant_type", "refresh_token"),
                 ("refresh_token", self.refresh_token.secret()),
@@ -1274,7 +1276,8 @@ where
             None,
             Some(&self.scopes),
             self.token_url
-                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?,
+                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?
+                .url(),
             vec![
                 ("grant_type", "password"),
                 ("username", self.username),
@@ -1386,21 +1389,22 @@ where
             None,
             Some(&self.scopes),
             self.token_url
-                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?,
+                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?
+                .url(),
             vec![("grant_type", "client_credentials")],
         ))
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-fn endpoint_request<'a, U: Into<&'a Url>>(
+fn endpoint_request<'a>(
     auth_type: &'a AuthType,
     client_id: &'a ClientId,
     client_secret: Option<&'a ClientSecret>,
     extra_params: &'a [(Cow<'a, str>, Cow<'a, str>)],
     redirect_url: Option<&'a RedirectUrl>,
     scopes: Option<&'a Vec<Cow<'a, Scope>>>,
-    url: U,
+    url: &'a Url,
     params: Vec<(&'a str, &'a str)>,
 ) -> HttpRequest {
     let mut headers = HeaderMap::new();
@@ -1477,7 +1481,7 @@ fn endpoint_request<'a, U: Into<&'a Url>>(
         .into_bytes();
 
     HttpRequest {
-        url: url.into().to_owned(),
+        url: url.to_owned(),
         method: http::method::Method::POST,
         headers,
         body,
@@ -1608,9 +1612,11 @@ where
             &self.extra_params,
             None,
             Some(&self.scopes),
-            self.device_authorization_url.ok_or_else(|| {
-                RequestTokenError::Other("no device authorization_url provided".to_string())
-            })?,
+            self.device_authorization_url
+                .ok_or_else(|| {
+                    RequestTokenError::Other("no device authorization_url provided".to_string())
+                })?
+                .url(),
             vec![],
         ))
     }
@@ -1811,7 +1817,7 @@ where
         C: Fn(HttpRequest) -> F,
         F: Future<Output = Result<HttpResponse, RE>>,
         S: Fn(Duration) -> SF,
-        SF: Future<Output=()>,
+        SF: Future<Output = ()>,
         RE: Error + 'static,
     {
         let details = self.device_authorization_details.ok_or_else(|| {
@@ -1871,7 +1877,8 @@ where
             None,
             None,
             self.token_url
-                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?,
+                .ok_or_else(|| RequestTokenError::Other("no token_url provided".to_string()))?
+                .url(),
             vec![
                 ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
                 ("device_code", details.device_code().secret()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,8 +449,11 @@ pub mod curl;
 /// ([RFC 8628](https://tools.ietf.org/html/rfc8628)).
 ///
 pub mod devicecode;
-use devicecode::{DeviceAuthorizationResponse, DeviceCodeAction, DeviceCodeErrorResponse, ExtraDeviceAuthorizationFields};
 pub use devicecode::StandardDeviceAuthorizationResponse;
+use devicecode::{
+    DeviceAuthorizationResponse, DeviceCodeAction, DeviceCodeErrorResponse,
+    ExtraDeviceAuthorizationFields,
+};
 
 ///
 /// Helper methods used by OAuth2 implementations/extensions.
@@ -752,7 +755,7 @@ where
     ) -> DeviceAccessTokenRequest<'b, TE, TR, TT, EF>
     where
         'a: 'b,
-        EF: ExtraDeviceAuthorizationFields
+        EF: ExtraDeviceAuthorizationFields,
     {
         DeviceAccessTokenRequest {
             auth_type: &self.auth_type,
@@ -1620,7 +1623,7 @@ where
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
         RE: Error + 'static,
-        EF: ExtraDeviceAuthorizationFields
+        EF: ExtraDeviceAuthorizationFields,
     {
         http_client(self.prepare_request()?)
             .map_err(RequestTokenError::Request)
@@ -1638,7 +1641,7 @@ where
         C: FnOnce(HttpRequest) -> F,
         F: Future<Output = Result<HttpResponse, RE>>,
         RE: Error + 'static,
-        EF: ExtraDeviceAuthorizationFields
+        EF: ExtraDeviceAuthorizationFields,
     {
         let http_request = self.prepare_request()?;
         let http_response = http_client(http_request)
@@ -1681,7 +1684,7 @@ where
     TE: ErrorResponse,
     TR: TokenResponse<TT>,
     TT: TokenType,
-    EF: ExtraDeviceAuthorizationFields
+    EF: ExtraDeviceAuthorizationFields,
 {
     auth_type: &'a AuthType,
     client_id: &'a ClientId,
@@ -1698,7 +1701,7 @@ where
     TE: ErrorResponse + 'static,
     TR: TokenResponse<TT>,
     TT: TokenType,
-    EF: ExtraDeviceAuthorizationFields
+    EF: ExtraDeviceAuthorizationFields,
 {
     ///
     /// Appends an extra param to the token request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1730,7 +1730,7 @@ where
         let details = self.dev_auth_resp;
 
         let mut elapsed = Duration::new(0, 0);
-        let mut interval = details.interval().clone();
+        let mut interval = details.interval();
 
         loop {
             if elapsed > details.expires_in() {
@@ -1783,7 +1783,7 @@ where
         let details = self.dev_auth_resp;
 
         let mut elapsed = Duration::new(0, 0);
-        let mut interval = details.interval().clone();
+        let mut interval = details.interval();
 
         loop {
             if elapsed > details.expires_in() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,11 +363,11 @@
 //!     ClientSecret,
 //!     DeviceAuthorizationUrl,
 //!     Scope,
-//!     StandardDeviceAuthorizationResponse,
 //!     TokenResponse,
 //!     TokenUrl
 //! };
 //! use oauth2::basic::BasicClient;
+//! use oauth2::devicecode::StandardDeviceAuthorizationResponse;
 //! use oauth2::reqwest::http_client;
 //! use url::Url;
 //!
@@ -449,7 +449,6 @@ pub mod curl;
 /// ([RFC 8628](https://tools.ietf.org/html/rfc8628)).
 ///
 pub mod devicecode;
-pub use devicecode::StandardDeviceAuthorizationResponse;
 use devicecode::{
     DeviceAccessTokenPollResult, DeviceAuthorizationResponse, DeviceCodeErrorResponse,
     DeviceCodeErrorResponseType, ExtraDeviceAuthorizationFields,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,10 +748,10 @@ where
     /// Perform a device access token request as per
     /// https://tools.ietf.org/html/rfc8628#section-3.4
     ///
-    pub fn exchange_device_access_token<'a, 'b, EF>(
+    pub fn exchange_device_access_token<'a, 'b, 'c, EF>(
         &'a self,
         auth_response: &'b DeviceAuthorizationResponse<EF>,
-    ) -> DeviceAccessTokenRequest<'b, TR, TT, EF>
+    ) -> DeviceAccessTokenRequest<'b, 'c, TR, TT, EF>
     where
         'a: 'b,
         EF: ExtraDeviceAuthorizationFields,
@@ -1656,7 +1656,7 @@ where
 /// See https://tools.ietf.org/html/rfc8628#section-3.4.
 ///
 #[derive(Clone)]
-pub struct DeviceAccessTokenRequest<'a, TR, TT, EF>
+pub struct DeviceAccessTokenRequest<'a, 'b, TR, TT, EF>
 where
     TR: TokenResponse<TT>,
     TT: TokenType,
@@ -1668,11 +1668,11 @@ where
     extra_params: Vec<(Cow<'a, str>, Cow<'a, str>)>,
     token_url: Option<&'a TokenUrl>,
     dev_auth_resp: &'a DeviceAuthorizationResponse<EF>,
-    time_fn: Arc<dyn Fn() -> DateTime<Utc> + 'a + Send + Sync>,
+    time_fn: Arc<dyn Fn() -> DateTime<Utc> + 'b + Send + Sync>,
     _phantom: PhantomData<(TR, TT, EF)>,
 }
 
-impl<'a, TR, TT, EF> DeviceAccessTokenRequest<'a, TR, TT, EF>
+impl<'a, 'b, TR, TT, EF> DeviceAccessTokenRequest<'a, 'b, TR, TT, EF>
 where
     TR: TokenResponse<TT>,
     TT: TokenType,
@@ -1709,7 +1709,7 @@ where
     ///
     pub fn set_time_fn<T>(mut self, time_fn: T) -> Self
     where
-        T: Fn() -> DateTime<Utc> + 'a + Send + Sync,
+        T: Fn() -> DateTime<Utc> + 'b + Send + Sync,
     {
         self.time_fn = Arc::new(time_fn);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1728,7 +1728,7 @@ where
     ) -> Result<TR, RequestTokenError<RE, DeviceCodeErrorResponse>>
     where
         F: Fn(HttpRequest) -> Result<HttpResponse, RE>,
-        S: Fn(Duration) -> (),
+        S: Fn(Duration),
         RE: Error + 'static,
     {
         let details = self.dev_auth_resp;
@@ -1736,14 +1736,14 @@ where
         // Calculate the request timeout - if the user specified a timeout,
         // use that, otherwise use the value given by the device authorization
         // response.
-        let timeout_dur = timeout.unwrap_or(details.expires_in());
+        let timeout_dur = timeout.unwrap_or_else(|| details.expires_in());
         let chrono_timeout = chrono::Duration::from_std(timeout_dur)
             .map_err(|_| RequestTokenError::Other("Failed to convert duration".to_string()))?;
 
         // Calculate the DateTime at which the request times out.
-        let timeout_dt = (*self.time_fn)().checked_add_signed(chrono_timeout).ok_or(
-            RequestTokenError::Other("Failed to calculate timeout".to_string()),
-        )?;
+        let timeout_dt = (*self.time_fn)()
+            .checked_add_signed(chrono_timeout)
+            .ok_or_else(|| RequestTokenError::Other("Failed to calculate timeout".to_string()))?;
 
         let mut interval = details.interval();
 
@@ -1787,14 +1787,14 @@ where
         // Calculate the request timeout - if the user specified a timeout,
         // use that, otherwise use the value given by the device authorization
         // response.
-        let timeout_dur = timeout.unwrap_or(details.expires_in());
+        let timeout_dur = timeout.unwrap_or_else(|| details.expires_in());
         let chrono_timeout = chrono::Duration::from_std(timeout_dur)
             .map_err(|_| RequestTokenError::Other("Failed to convert duration".to_string()))?;
 
         // Calculate the DateTime at which the request times out.
-        let timeout_dt = (*self.time_fn)().checked_add_signed(chrono_timeout).ok_or(
-            RequestTokenError::Other("Failed to calculate timeout".to_string()),
-        )?;
+        let timeout_dt = (*self.time_fn)()
+            .checked_add_signed(chrono_timeout)
+            .ok_or_else(|| RequestTokenError::Other("Failed to calculate timeout".to_string()))?;
 
         let mut interval = details.interval();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1632,7 +1632,7 @@ where
     {
         http_client(self.prepare_request()?)
             .map_err(RequestTokenError::Request)
-            .and_then(device_authorization_response)
+            .and_then(endpoint_response)
     }
 
     ///
@@ -1651,29 +1651,8 @@ where
         let http_response = http_client(http_request)
             .await
             .map_err(RequestTokenError::Request)?;
-        device_authorization_response(http_response)
+        endpoint_response(http_response)
     }
-}
-
-///
-/// Maps an HTTP response to Device Code authorization details.  These details
-/// are used to display the verification URI and the user code to the user.
-///
-fn device_authorization_response<RE, TE>(
-    http_response: HttpResponse,
-) -> Result<DeviceAuthorizationResponse, RequestTokenError<RE, TE>>
-where
-    RE: Error + 'static,
-    TE: ErrorResponse,
-{
-    // Clone the body for any parser error response.
-    let body = http_response.body.clone();
-
-    endpoint_response(http_response).and_then(|rsp| {
-        let val: Result<DeviceAuthorizationResponse, serde_json::Error> =
-            serde_json::from_value(rsp);
-        val.map_err(|err| RequestTokenError::Parse(err, body))
-    })
 }
 
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,7 @@
 //! println!(
 //!     "Open this URL in your browser:\n{}\nand enter the code: {}",
 //!     details.verification_uri().to_string(),
-//!     details.user_code().to_string()
+//!     details.user_code().secret().to_string()
 //! );
 //!
 //! let token_result =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,8 +451,8 @@ pub mod curl;
 pub mod devicecode;
 pub use devicecode::StandardDeviceAuthorizationResponse;
 use devicecode::{
-    DeviceAccessResult, DeviceAccessTokenPollResult, DeviceAuthorizationResponse,
-    DeviceCodeErrorResponse, DeviceCodeErrorResponseType, ExtraDeviceAuthorizationFields,
+    DeviceAccessTokenPollResult, DeviceAuthorizationResponse, DeviceCodeErrorResponse,
+    DeviceCodeErrorResponseType, ExtraDeviceAuthorizationFields,
 };
 
 ///
@@ -1758,7 +1758,7 @@ where
                 DeviceAccessTokenPollResult::ContinueWithNewPollInterval(new_interval) => {
                     interval = new_interval
                 }
-                DeviceAccessTokenPollResult::Done(res) => break res.result(),
+                DeviceAccessTokenPollResult::Done(res, _) => break res,
             }
 
             // Sleep here using the provided sleep function.
@@ -1809,7 +1809,7 @@ where
                 DeviceAccessTokenPollResult::ContinueWithNewPollInterval(new_interval) => {
                     interval = new_interval
                 }
-                DeviceAccessTokenPollResult::Done(res) => break res.result(),
+                DeviceAccessTokenPollResult::Done(res, _) => break res,
             }
 
             // Sleep here using the provided sleep function.
@@ -1876,14 +1876,15 @@ where
                     }
 
                     // On any other error, just return the error.
-                    _ => DeviceAccessTokenPollResult::Done(DeviceAccessResult::new(Err(
-                        RequestTokenError::ServerResponse(dcer),
-                    ))),
+                    _ => DeviceAccessTokenPollResult::Done(
+                        Err(RequestTokenError::ServerResponse(dcer)),
+                        PhantomData,
+                    ),
                 }
             }
 
             // On any other success or failure, return the failure.
-            res => DeviceAccessTokenPollResult::Done(DeviceAccessResult::new(res)),
+            res => DeviceAccessTokenPollResult::Done(res, PhantomData),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,7 @@ pub mod curl;
 /// ([RFC 8628](https://tools.ietf.org/html/rfc8628)).
 ///
 pub mod devicecode;
-use devicecode::{DeviceAuthorizationDetails, DeviceCodeAction, DeviceCodeErrorResponse};
+use devicecode::{DeviceAuthorizationResponse, DeviceCodeAction, DeviceCodeErrorResponse};
 
 ///
 /// Helper methods used by OAuth2 implementations/extensions.
@@ -519,7 +519,7 @@ where
     token_url: Option<TokenUrl>,
     redirect_url: Option<RedirectUrl>,
     device_authorization_url: Option<DeviceAuthorizationUrl>,
-    device_authorization_details: Option<DeviceAuthorizationDetails>,
+    device_authorization_details: Option<DeviceAuthorizationResponse>,
     phantom_te: PhantomData<TE>,
     phantom_tr: PhantomData<TR>,
     phantom_tt: PhantomData<TT>,
@@ -613,7 +613,7 @@ where
     ///
     pub fn set_device_authorization_details(
         mut self,
-        device_authorization_details: DeviceAuthorizationDetails,
+        device_authorization_details: DeviceAuthorizationResponse,
     ) -> Self {
         self.device_authorization_details = Some(device_authorization_details);
 
@@ -1606,7 +1606,7 @@ where
         Ok(endpoint_request(
             self.auth_type,
             self.client_id,
-            None,
+            self.client_secret,
             &self.extra_params,
             None,
             Some(&self.scopes),
@@ -1625,7 +1625,7 @@ where
     pub fn request<F, RE>(
         self,
         http_client: F,
-    ) -> Result<DeviceAuthorizationDetails, RequestTokenError<RE, TE>>
+    ) -> Result<DeviceAuthorizationResponse, RequestTokenError<RE, TE>>
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
         RE: Error + 'static,
@@ -1641,7 +1641,7 @@ where
     pub async fn request_async<C, F, RE>(
         self,
         http_client: C,
-    ) -> Result<DeviceAuthorizationDetails, RequestTokenError<RE, TE>>
+    ) -> Result<DeviceAuthorizationResponse, RequestTokenError<RE, TE>>
     where
         C: FnOnce(HttpRequest) -> F,
         F: Future<Output = Result<HttpResponse, RE>>,
@@ -1661,7 +1661,7 @@ where
 ///
 fn device_authorization_response<RE, TE>(
     http_response: HttpResponse,
-) -> Result<DeviceAuthorizationDetails, RequestTokenError<RE, TE>>
+) -> Result<DeviceAuthorizationResponse, RequestTokenError<RE, TE>>
 where
     RE: Error + 'static,
     TE: ErrorResponse,
@@ -1670,7 +1670,7 @@ where
     let body = http_response.body.clone();
 
     endpoint_response(http_response).and_then(|rsp| {
-        let val: Result<DeviceAuthorizationDetails, serde_json::Error> =
+        let val: Result<DeviceAuthorizationResponse, serde_json::Error> =
             serde_json::from_value(rsp);
         val.map_err(|err| RequestTokenError::Parse(err, body))
     })
@@ -1715,7 +1715,7 @@ where
     client_secret: Option<&'a ClientSecret>,
     extra_params: Vec<(Cow<'a, str>, Cow<'a, str>)>,
     token_url: Option<&'a TokenUrl>,
-    device_authorization_details: Option<&'a DeviceAuthorizationDetails>,
+    device_authorization_details: Option<&'a DeviceAuthorizationResponse>,
     _phantom: PhantomData<(TE, TR, TT)>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1036,7 +1036,7 @@ where
     {
         http_client(self.prepare_request()?)
             .map_err(RequestTokenError::Request)
-            .and_then(token_response)
+            .and_then(endpoint_response)
     }
 
     ///
@@ -1055,7 +1055,7 @@ where
         let http_response = http_client(http_request)
             .await
             .map_err(RequestTokenError::Request)?;
-        token_response(http_response)
+        endpoint_response(http_response)
     }
 }
 
@@ -1128,7 +1128,7 @@ where
     {
         http_client(self.prepare_request()?)
             .map_err(RequestTokenError::Request)
-            .and_then(token_response)
+            .and_then(endpoint_response)
     }
     ///
     /// Asynchronously sends the request to the authorization server and awaits a response.
@@ -1146,7 +1146,7 @@ where
         let http_response = http_client(http_request)
             .await
             .map_err(RequestTokenError::Request)?;
-        token_response(http_response)
+        endpoint_response(http_response)
     }
 
     fn prepare_request<RE>(&self) -> Result<HttpRequest, RequestTokenError<RE, TE>>
@@ -1240,7 +1240,7 @@ where
     {
         http_client(self.prepare_request()?)
             .map_err(RequestTokenError::Request)
-            .and_then(token_response)
+            .and_then(endpoint_response)
     }
 
     ///
@@ -1259,7 +1259,7 @@ where
         let http_response = http_client(http_request)
             .await
             .map_err(RequestTokenError::Request)?;
-        token_response(http_response)
+        endpoint_response(http_response)
     }
 
     fn prepare_request<RE>(&self) -> Result<HttpRequest, RequestTokenError<RE, TE>>
@@ -1352,7 +1352,7 @@ where
     {
         http_client(self.prepare_request()?)
             .map_err(RequestTokenError::Request)
-            .and_then(token_response)
+            .and_then(endpoint_response)
     }
 
     ///
@@ -1371,7 +1371,7 @@ where
         let http_response = http_client(http_request)
             .await
             .map_err(RequestTokenError::Request)?;
-        token_response(http_response)
+        endpoint_response(http_response)
     }
 
     fn prepare_request<RE>(&self) -> Result<HttpRequest, RequestTokenError<RE, TE>>
@@ -1539,18 +1539,6 @@ where
         serde_json::from_slice(response_body)
             .map_err(|e| RequestTokenError::Parse(e, response_body.to_vec()))
     }
-}
-
-fn token_response<RE, TE, TR, TT>(
-    http_response: HttpResponse,
-) -> Result<TR, RequestTokenError<RE, TE>>
-where
-    RE: Error + 'static,
-    TE: ErrorResponse,
-    TR: TokenResponse<TT>,
-    TT: TokenType,
-{
-    endpoint_response(http_response)
 }
 
 ///
@@ -1788,7 +1776,7 @@ where
                 .map_err(|_| DeviceCodeAction::DoubleIntervalThenRetry)
                 .and_then(device_token_action)
             {
-                Ok(http_response) => break token_response(http_response),
+                Ok(http_response) => break endpoint_response(http_response),
                 Err(DeviceCodeAction::Retry) => {
                     // Wait for the current interval.
                 }
@@ -1802,7 +1790,7 @@ where
                         "Failed to increase interval".to_string(),
                     ))?;
                 }
-                Err(DeviceCodeAction::NoFurtherRequests(req)) => break token_response(req),
+                Err(DeviceCodeAction::NoFurtherRequests(req)) => break endpoint_response(req),
             };
 
             // Sleep here using the provided sleep function.
@@ -1844,7 +1832,7 @@ where
                 .map_err(|_| DeviceCodeAction::DoubleIntervalThenRetry)
                 .and_then(device_token_action)
             {
-                Ok(http_response) => break token_response(http_response),
+                Ok(http_response) => break endpoint_response(http_response),
                 Err(DeviceCodeAction::Retry) => {
                     // Wait for the current interval.
                 }
@@ -1858,7 +1846,7 @@ where
                         "Failed to increase interval".to_string(),
                     ))?;
                 }
-                Err(DeviceCodeAction::NoFurtherRequests(req)) => break token_response(req),
+                Err(DeviceCodeAction::NoFurtherRequests(req)) => break endpoint_response(req),
             };
 
             // Use the user-defined function to sleep asynchronously.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1562,7 +1562,8 @@ fn test_exchange_device_code_and_token() {
                 .to_string()
                 .into_bytes(),
             },
-        ))
+        ),
+        std::thread::sleep)
         .unwrap();
 
     assert_eq!("12/34", token.access_token().secret());
@@ -1614,7 +1615,8 @@ fn test_device_token_authorization_timeout() {
                 .to_string()
                 .into_bytes(),
             },
-        ))
+        ),
+        std::thread::sleep)
         .err()
         .unwrap();
     match token {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1567,7 +1567,8 @@ fn test_exchange_device_code_and_token() {
                 .into_bytes(),
             },
         ),
-        std::thread::sleep)
+        std::thread::sleep,
+        None)
         .unwrap();
 
     assert_eq!("12/34", token.access_token().secret());
@@ -1623,7 +1624,8 @@ fn test_device_token_authorization_timeout() {
                 .into_bytes(),
             },
         ),
-        std::thread::sleep)
+        std::thread::sleep,
+        None)
         .err()
         .unwrap();
     match token {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1480,7 +1480,7 @@ fn test_secret_redaction() {
     assert_eq!("ClientSecret([redacted])", format!("{:?}", secret));
 }
 
-fn new_device_auth_details(expires_in: u32) -> DeviceAuthorizationResponse {
+fn new_device_auth_details(expires_in: u32) -> StandardDeviceAuthorizationResponse {
     let body = format!(
         "{{\
         \"device_code\": \"12345\", \
@@ -1714,12 +1714,13 @@ fn test_send_sync_impl() {
     is_sync_and_send::<EndUserVerificationUrl>();
     is_sync_and_send::<UserCode>();
     is_sync_and_send::<DeviceAuthorizationUrl>();
-    is_sync_and_send::<DeviceAuthorizationResponse>();
+    is_sync_and_send::<StandardDeviceAuthorizationResponse>();
     is_sync_and_send::<
         DeviceAccessTokenRequest<
             StandardErrorResponse<BasicErrorResponseType>,
             StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
             BasicTokenType,
+            EmptyExtraDeviceAuthorizationFields
         >,
     >();
     is_sync_and_send::<DeviceAuthorizationRequest<StandardErrorResponse<BasicErrorResponseType>>>();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1717,14 +1717,12 @@ fn test_send_sync_impl() {
     is_sync_and_send::<StandardDeviceAuthorizationResponse>();
     is_sync_and_send::<
         DeviceAccessTokenRequest<
-            StandardErrorResponse<BasicErrorResponseType>,
             StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
             BasicTokenType,
             EmptyExtraDeviceAuthorizationFields,
         >,
     >();
     is_sync_and_send::<DeviceAuthorizationRequest<StandardErrorResponse<BasicErrorResponseType>>>();
-    is_sync_and_send::<DeviceCodeAction<HttpResponse>>();
     is_sync_and_send::<DeviceCodeErrorResponseType>();
     is_sync_and_send::<DeviceCodeErrorResponse>();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1545,9 +1545,7 @@ fn mock_time_fn() -> impl Fn() -> DateTime<Utc> + Send + Sync {
 }
 
 /// Mock sleep function that doesn't actually sleep.
-fn mock_sleep_fn(dur: Duration) {
-    println!("Mock sleep for {:?}", dur);
-}
+fn mock_sleep_fn(_: Duration) {}
 
 #[test]
 fn test_exchange_device_code_and_token() {
@@ -1782,10 +1780,10 @@ fn mock_http_client_success_fail(
     num_failures: usize,
     success_response: HttpResponse,
 ) -> impl Fn(HttpRequest) -> Result<HttpResponse, FakeError> {
-    let mut responses: Vec<HttpResponse> = std::iter::repeat(failure_response)
+    let responses: Vec<HttpResponse> = std::iter::repeat(failure_response)
         .take(num_failures)
+        .chain(std::iter::once(success_response))
         .collect();
-    responses.push(success_response);
     let sync_responses = std::sync::Mutex::new(responses);
 
     move |request: HttpRequest| {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1507,7 +1507,7 @@ fn new_device_auth_details(expires_in: u32) -> DeviceAuthorizationResponse {
                 (CONTENT_TYPE, "application/x-www-form-urlencoded"),
                 (AUTHORIZATION, "Basic YWFhOmJiYg=="),
             ],
-            "scope=openid&client_id=aaa&foo=bar",
+            "scope=openid&foo=bar",
             Some(device_auth_url.url().to_owned()),
             HttpResponse {
                 status_code: StatusCode::OK,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1480,7 +1480,7 @@ fn test_secret_redaction() {
     assert_eq!("ClientSecret([redacted])", format!("{:?}", secret));
 }
 
-fn new_device_auth_details(expires_in: u32) -> DeviceAuthorizationDetails {
+fn new_device_auth_details(expires_in: u32) -> DeviceAuthorizationResponse {
     let body = format!(
         "{{\
         \"device_code\": \"12345\", \
@@ -1505,6 +1505,7 @@ fn new_device_auth_details(expires_in: u32) -> DeviceAuthorizationDetails {
             vec![
                 (ACCEPT, "application/json"),
                 (CONTENT_TYPE, "application/x-www-form-urlencoded"),
+                (AUTHORIZATION, "Basic YWFhOmJiYg=="),
             ],
             "scope=openid&client_id=aaa&foo=bar",
             Some(device_auth_url.url().to_owned()),
@@ -1705,7 +1706,7 @@ fn test_send_sync_impl() {
     is_sync_and_send::<EndUserVerificationUrl>();
     is_sync_and_send::<UserCode>();
     is_sync_and_send::<DeviceAuthorizationUrl>();
-    is_sync_and_send::<DeviceAuthorizationDetails>();
+    is_sync_and_send::<DeviceAuthorizationResponse>();
     is_sync_and_send::<
         DeviceAccessTokenRequest<
             StandardErrorResponse<BasicErrorResponseType>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1537,8 +1537,7 @@ fn test_exchange_device_code_and_token() {
     assert_eq!(Duration::from_secs(1), details.interval());
 
     let token = new_client()
-        .set_device_authorization_details(details)
-        .exchange_device_access_token()
+        .exchange_device_access_token(&details)
         .request(mock_http_client(
             vec![
                 (ACCEPT, "application/json"),
@@ -1591,8 +1590,7 @@ fn test_device_token_authorization_timeout() {
     assert_eq!(Duration::from_secs(1), details.interval());
 
     let token = new_client()
-        .set_device_authorization_details(details)
-        .exchange_device_access_token()
+        .exchange_device_access_token(&details)
         .request(mock_http_client(
             vec![
                 (ACCEPT, "application/json"),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1528,10 +1528,14 @@ fn test_exchange_device_code_and_token() {
     let details = new_device_auth_details(3600);
     assert_eq!("12345", details.device_code().secret());
     assert_eq!("https://verify/here", details.verification_uri().as_str());
-    assert_eq!("abcde", details.user_code().as_str());
+    assert_eq!("abcde", details.user_code().secret().as_str());
     assert_eq!(
         "https://verify/here?abcde",
-        details.verification_uri_complete().unwrap().as_str()
+        details
+            .verification_uri_complete()
+            .unwrap()
+            .secret()
+            .as_str()
     );
     assert_eq!(Duration::from_secs(3600), details.expires_in());
     assert_eq!(Duration::from_secs(1), details.interval());
@@ -1581,10 +1585,14 @@ fn test_device_token_authorization_timeout() {
     let details = new_device_auth_details(2);
     assert_eq!("12345", details.device_code().secret());
     assert_eq!("https://verify/here", details.verification_uri().as_str());
-    assert_eq!("abcde", details.user_code().as_str());
+    assert_eq!("abcde", details.user_code().secret().as_str());
     assert_eq!(
         "https://verify/here?abcde",
-        details.verification_uri_complete().unwrap().as_str()
+        details
+            .verification_uri_complete()
+            .unwrap()
+            .secret()
+            .as_str()
     );
     assert_eq!(Duration::from_secs(2), details.expires_in());
     assert_eq!(Duration::from_secs(1), details.interval());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1720,7 +1720,7 @@ fn test_send_sync_impl() {
             StandardErrorResponse<BasicErrorResponseType>,
             StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
             BasicTokenType,
-            EmptyExtraDeviceAuthorizationFields
+            EmptyExtraDeviceAuthorizationFields,
         >,
     >();
     is_sync_and_send::<DeviceAuthorizationRequest<StandardErrorResponse<BasicErrorResponseType>>>();

--- a/src/types.rs
+++ b/src/types.rs
@@ -255,6 +255,11 @@ macro_rules! new_url_type {
                 &self.1
             }
         }
+        impl <'a> Into<&'a Url> for &'a $name {
+            fn into(self) -> &'a Url {
+                self.url()
+            }
+        }
         impl ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
                 let mut debug_trait_builder = f.debug_tuple(stringify!($name));
@@ -346,6 +351,18 @@ new_url_type![
     /// URL of the client's redirection endpoint.
     ///
     RedirectUrl
+];
+new_url_type![
+    ///
+    /// URL of the client's device authorization endpoint.
+    ///
+    DeviceAuthorizationUrl
+];
+new_url_type![
+    ///
+    /// URL of the end-user verification URI on the authorization server.
+    ///
+    EndUserVerificationUrl
 ];
 new_type![
     ///
@@ -546,4 +563,19 @@ new_secret_type![
     ///
     #[derive(Clone)]
     ResourceOwnerPassword(String)
+];
+new_secret_type![
+    ///
+    /// Device code returned by the device authorization endpoint and used to query the token endpoint.
+    ///
+    #[derive(Clone, Deserialize, Serialize)]
+    DeviceCode(String)
+];
+new_type![
+    ///
+    /// User code returned by the device authorization endpoint and used by the user to authorize at
+    /// the verification URI.
+    ///
+    #[derive(Deserialize, Serialize)]
+    UserCode(String)
 ];

--- a/src/types.rs
+++ b/src/types.rs
@@ -255,11 +255,6 @@ macro_rules! new_url_type {
                 &self.1
             }
         }
-        impl <'a> Into<&'a Url> for &'a $name {
-            fn into(self) -> &'a Url {
-                self.url()
-            }
-        }
         impl ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
                 let mut debug_trait_builder = f.debug_tuple(stringify!($name));

--- a/src/types.rs
+++ b/src/types.rs
@@ -566,11 +566,19 @@ new_secret_type![
     #[derive(Clone, Deserialize, Serialize)]
     DeviceCode(String)
 ];
-new_type![
+new_secret_type![
+    ///
+    /// Verification URI returned by the device authorization endpoint and visited by the user
+    /// to authorize.  Contains the user code.
+    ///
+    #[derive(Clone, Deserialize, Serialize)]
+    VerificationUriComplete(String)
+];
+new_secret_type![
     ///
     /// User code returned by the device authorization endpoint and used by the user to authorize at
     /// the verification URI.
     ///
-    #[derive(Deserialize, Serialize)]
+    #[derive(Clone, Deserialize, Serialize)]
     UserCode(String)
 ];


### PR DESCRIPTION
- Add `Client` methods to set up the device authorization url and details
- Add `Client` methods to exchange for device codes, and to exchange codes
  for a token.
- Add an example that authorizes using Device Code Flow against Google.

All async code works as well - I had to add a dependency on `async-std` to provide `async_std::task::sleep` for an async sleep.

No tests have been added yet, but an example program has been added which authorizes against Google using Device Code Flow. I'm planning on adding tests in an additional commit in this PR.

```
md/devicecodeflow :~/code/github/maxdymond/oauth2-rs$ cargo run --example google_devicecode
   Compiling oauth2 v4.0.0-alpha.2 (/home/md/code/github/maxdymond/oauth2-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 4.51s
     Running `target/debug/examples/google_devicecode`
Open this URL in your browser:
https://www.google.com/device
and enter the code: DEAD-BEEF
Google returned the following token:
StandardTokenResponse { access_token: AccessToken([redacted]), token_type: Bearer, expires_in: Some(3599), refresh_token: Some(RefreshToken([redacted])), scopes: Some([Scope("https://www.googleapis.com/auth/userinfo.profile")]), extra_fields: EmptyExtraTokenFields }
```