### PR TITLE
Add "plain" pkce mode, refactor sha256 to share code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = ["reqwest-010"]
+pkce-plain = []
 reqwest-010 = ["reqwest-0-10"]
 
 [dependencies]


### PR DESCRIPTION
I implemented this to talk to a third-party API that doesn't support any PKCE challenge types besides "plain". I split out PkceCodeVerifier creation from the sha256 functions so it can be shared with other challenge type implementations. I'm pretty new to rust, so please let me know if there was a better way to achieve this.