### PR TITLE
Bump to `tokio 1.0` and `reqwest 0.11`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["reqwest-010"]
+default = ["reqwest-011"]
 pkce-plain = []
-reqwest-010 = ["reqwest-0-10"]
+reqwest-011 = ["reqwest-0-11"]
 
 [dependencies]
 base64 = "0.12"
@@ -25,7 +25,7 @@ curl = { version = "0.4.0", optional = true }
 thiserror="1.0"
 http = "0.2"
 rand = "0.7"
-reqwest-0-10 = { version = "0.10", optional = true, features = ["blocking", "rustls-tls"], package = "reqwest", default-features = false }
+reqwest-0-11 = { version = "0.11", optional = true, features = ["blocking", "rustls-tls"], package = "reqwest", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"
@@ -37,5 +37,5 @@ hex = "0.4"
 hmac = "0.8"
 uuid = { version = "0.8", features = ["v4"] }
 anyhow="1.0"
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }
 async-std = "1.6.3"

--- a/examples/github_async.rs
+++ b/examples/github_async.rs
@@ -67,7 +67,7 @@ async fn main() {
     );
 
     // A very naive implementation of the redirect server.
-    let mut listener = TcpListener::bind("127.0.0.1:8080").await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:8080").await.unwrap();
     loop {
         if let Ok((mut stream, _)) = listener.accept().await {
             let code;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,11 +163,11 @@
 //!     TokenUrl
 //! };
 //! use oauth2::basic::BasicClient;
-//! # #[cfg(feature = "reqwest-010")]
+//! # #[cfg(feature = "reqwest-011")]
 //! use oauth2::reqwest::async_http_client;
 //! use url::Url;
 //!
-//! # #[cfg(feature = "reqwest-010")]
+//! # #[cfg(feature = "reqwest-011")]
 //! # async fn err_wrapper() -> Result<(), anyhow::Error> {
 //! // Create an OAuth2 client by specifying the client ID, client secret, authorization URL and
 //! // token URL.
@@ -462,9 +462,9 @@ pub mod helpers;
 
 ///
 /// HTTP client backed by the [reqwest](https://crates.io/crates/reqwest) crate.
-/// Requires "reqwest-010" feature.
+/// Requires "reqwest-011" feature.
 ///
-#[cfg(feature = "reqwest-010")]
+#[cfg(feature = "reqwest-011")]
 pub mod reqwest;
 
 #[cfg(test)]

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -33,15 +33,15 @@ pub use async_client::async_http_client;
 ///
 /// Error type returned by failed reqwest async HTTP requests.
 ///
-pub type AsyncHttpClientError = Error<reqwest_0_10::Error>;
+pub type AsyncHttpClientError = Error<reqwest_0_11::Error>;
 
 mod blocking {
     use super::super::{HttpRequest, HttpResponse};
     use super::Error;
 
-    pub use reqwest_0_10 as reqwest;
-    use reqwest_0_10::blocking;
-    use reqwest_0_10::redirect::Policy as RedirectPolicy;
+    pub use reqwest_0_11 as reqwest;
+    use reqwest_0_11::blocking;
+    use reqwest_0_11::redirect::Policy as RedirectPolicy;
 
     use std::io::Read;
 
@@ -55,7 +55,7 @@ mod blocking {
             .build()
             .map_err(Error::Reqwest)?;
 
-        #[cfg(feature = "reqwest-010")]
+        #[cfg(feature = "reqwest-011")]
         let mut request_builder = client
             .request(request.method, request.url.as_str())
             .body(request.body);
@@ -70,7 +70,7 @@ mod blocking {
         let mut body = Vec::new();
         response.read_to_end(&mut body).map_err(Error::Io)?;
 
-        #[cfg(feature = "reqwest-010")]
+        #[cfg(feature = "reqwest-011")]
         {
             Ok(HttpResponse {
                 status_code: response.status(),
@@ -85,8 +85,8 @@ mod async_client {
     use super::super::{HttpRequest, HttpResponse};
     use super::Error;
 
-    pub use reqwest_0_10 as reqwest;
-    use reqwest_0_10::redirect::Policy as RedirectPolicy;
+    pub use reqwest_0_11 as reqwest;
+    use reqwest_0_11::redirect::Policy as RedirectPolicy;
 
     ///
     /// Asynchronous HTTP client.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2211,6 +2211,6 @@ fn test_send_sync_impl() {
 
     #[cfg(feature = "curl")]
     is_sync_and_send::<super::curl::Error>();
-    #[cfg(feature = "reqwest-010")]
+    #[cfg(feature = "reqwest-011")]
     is_sync_and_send::<super::reqwest::Error<TestError>>();
 }


### PR DESCRIPTION
This drops the feature `reqwest-010` and replaces it with `reqwest-011` based on the new `reqwest 0.11` release. The version of tokio used in tests is also bumped to the stable 1.0 release.

cc #99