### PR TITLE
wasm32 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ pkce-plain = []
 
 [dependencies]
 base64 = "0.12"
-curl = { version = "0.4.0", optional = true }
 thiserror="1.0"
 http = "0.2"
 rand = "0.7"
@@ -30,6 +29,9 @@ serde_json = "1.0"
 sha2 = "0.9"
 url = { version = "2.1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+curl = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,8 +442,11 @@ pub mod basic;
 /// HTTP client backed by the [curl](https://crates.io/crates/curl) crate.
 /// Requires "curl" feature.
 ///
-#[cfg(feature = "curl")]
+#[cfg(all(feature = "curl", not(target_arch = "wasm32")))]
 pub mod curl;
+
+#[cfg(all(feature = "curl", target_arch = "wasm32"))]
+compile_error!("wasm32 is not supported with the `curl` feature. Use the `reqwest` backend or a custom backend for wasm32 support");
 
 ///
 /// Device Code Flow OAuth2 implementation
@@ -2112,7 +2115,7 @@ where
     fn refresh_token(&self) -> Option<&RefreshToken>;
     ///
     /// OPTIONAL, if identical to the scope requested by the client; otherwise, REQUIRED. The
-    /// scipe of the access token as described by
+    /// scope of the access token as described by
     /// [Section 3.3](https://tools.ietf.org/html/rfc6749#section-3.3). If included in the response,
     /// this space-delimited field is parsed into a `Vec` of individual scopes. If omitted from
     /// the response, this field is `None`.
@@ -2258,7 +2261,7 @@ where
     }
     ///
     /// OPTIONAL, if identical to the scope requested by the client; otherwise, REQUIRED. The
-    /// scipe of the access token as described by
+    /// scope of the access token as described by
     /// [Section 3.3](https://tools.ietf.org/html/rfc6749#section-3.3). If included in the response,
     /// this space-delimited field is parsed into a `Vec` of individual scopes. If omitted from
     /// the response, this field is `None`.


### PR DESCRIPTION
since reqwest already supports wasm32 targets, and all dependencies of this crate are already platform-agnostic, by disabling the blocking client implementation (which does not exist on wasm platforms), the crate can be used in wasm.
The curl backend, obviously, does not work in wasm targets, so a gate has been added to prevent its compilation with a simple error message for the user. The curl dependency has been made conditional so that it does not get compiled for wasm targets, preventing a wall of error messages hiding the error from this crate.