### PR TITLE
RFC 7009 OAuth 2.0 Token Revocation

### DIFF
--- a/examples/google.rs
+++ b/examples/google.rs
@@ -13,11 +13,7 @@
 //! ...and follow the instructions.
 //!
 
-use oauth2::{
-    basic::BasicClient,
-    revocation::{StandardRevocableToken, StandardRevocationResponse},
-    TokenResponse,
-};
+use oauth2::{basic::BasicClient, revocation::StandardRevocableToken, TokenResponse};
 // Alternatively, this can be oauth2::curl::http_client or a custom.
 use oauth2::reqwest::http_client;
 use oauth2::{
@@ -148,23 +144,17 @@ fn main() {
 
             // Revoke the obtained token
             let token_response = token_response.unwrap();
-            let token_to_revoke = if let Some(token) = token_response.refresh_token() {
-                StandardRevocableToken::RefreshToken(token.clone())
-            } else {
-                StandardRevocableToken::AccessToken(token_response.access_token().clone())
+            let token_to_revoke: StandardRevocableToken = match token_response.refresh_token() {
+                Some(token) => token.into(),
+                None => token_response.access_token().into(),
             };
 
-            let revocation_response: StandardRevocationResponse = client
+            client
                 .revoke_token(token_to_revoke)
                 .request(http_client)
                 .expect("Failed to revoke token");
 
-            println!(
-                "Google returned the following revocation response:\n{:?}\n",
-                revocation_response
-            );
-
-            // The server will terminate itself after collecting the first code.
+            // The server will terminate itself after revoking the token.
             break;
         }
     }

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -13,7 +13,11 @@
 //! ...and follow the instructions.
 //!
 
-use oauth2::{TokenResponse, basic::BasicClient, revocation::{StandardRevocableToken, StandardRevocationResponse}};
+use oauth2::{
+    basic::BasicClient,
+    revocation::{StandardRevocableToken, StandardRevocationResponse},
+    TokenResponse,
+};
 // Alternatively, this can be oauth2::curl::http_client or a custom.
 use oauth2::reqwest::http_client;
 use oauth2::{
@@ -52,7 +56,8 @@ fn main() {
     )
     // Google supports OAuth 2.0 Token Revocation (RFC-7009)
     .set_revocation_url(
-        RevocationUrl::new("https://oauth2.googleapis.com/revoke".to_string()).expect("Invalid revocation endpoint URL"),
+        RevocationUrl::new("https://oauth2.googleapis.com/revoke".to_string())
+            .expect("Invalid revocation endpoint URL"),
     );
 
     // Google supports Proof Key for Code Exchange (PKCE - https://oauth.net/2/pkce/).
@@ -136,7 +141,10 @@ fn main() {
                 .set_pkce_verifier(pkce_code_verifier)
                 .request(http_client);
 
-            println!("Google returned the following token:\n{:?}\n", token_response);
+            println!(
+                "Google returned the following token:\n{:?}\n",
+                token_response
+            );
 
             // Revoke the obtained token
             let token_response = token_response.unwrap();
@@ -151,7 +159,10 @@ fn main() {
                 .request(http_client)
                 .expect("Failed to revoke token");
 
-            println!("Google returned the following revocation response:\n{:?}\n", revocation_response);
+            println!(
+                "Google returned the following revocation response:\n{:?}\n",
+                revocation_response
+            );
 
             // The server will terminate itself after collecting the first code.
             break;

--- a/examples/wunderlist.rs
+++ b/examples/wunderlist.rs
@@ -14,11 +14,14 @@
 //! ...and follow the instructions.
 //!
 
-use oauth2::basic::{
-    BasicErrorResponse, BasicRevocableToken, BasicRevocationErrorResponse,
-    BasicTokenIntrospectionResponse, BasicTokenType,
-};
 use oauth2::TokenType;
+use oauth2::{
+    basic::{
+        BasicErrorResponse, BasicRevocationErrorResponse, BasicTokenIntrospectionResponse,
+        BasicTokenType,
+    },
+    revocation::StandardRevocableToken,
+};
 // Alternatively, this can be `oauth2::curl::http_client` or a custom client.
 use oauth2::helpers;
 use oauth2::reqwest::http_client;
@@ -38,7 +41,7 @@ use url::Url;
 
 type SpecialTokenResponse = NonStandardTokenResponse<EmptyExtraTokenFields>;
 type SpecialClient = Client<
-    BasicRevocableToken,
+    StandardRevocableToken,
     BasicErrorResponse,
     SpecialTokenResponse,
     BasicTokenType,

--- a/examples/wunderlist.rs
+++ b/examples/wunderlist.rs
@@ -41,11 +41,11 @@ use url::Url;
 
 type SpecialTokenResponse = NonStandardTokenResponse<EmptyExtraTokenFields>;
 type SpecialClient = Client<
-    StandardRevocableToken,
     BasicErrorResponse,
     SpecialTokenResponse,
     BasicTokenType,
     BasicTokenIntrospectionResponse,
+    StandardRevocableToken,
     BasicRevocationErrorResponse,
 >;
 

--- a/examples/wunderlist.rs
+++ b/examples/wunderlist.rs
@@ -14,7 +14,7 @@
 //! ...and follow the instructions.
 //!
 
-use oauth2::basic::{BasicErrorResponse, BasicTokenInspectionResponse, BasicTokenType};
+use oauth2::basic::{BasicErrorResponse, BasicRevocableToken, BasicRevocationErrorResponse, BasicTokenInspectionResponse, BasicTokenType};
 use oauth2::TokenType;
 // Alternatively, this can be `oauth2::curl::http_client` or a custom client.
 use oauth2::helpers;
@@ -35,7 +35,7 @@ use url::Url;
 
 type SpecialTokenResponse = NonStandardTokenResponse<EmptyExtraTokenFields>;
 type SpecialClient =
-    Client<BasicErrorResponse, SpecialTokenResponse, BasicTokenType, BasicTokenInspectionResponse>;
+    Client<BasicRevocableToken, BasicErrorResponse, SpecialTokenResponse, BasicTokenType, BasicTokenInspectionResponse, BasicRevocationErrorResponse>;
 
 fn default_token_type() -> Option<BasicTokenType> {
     Some(BasicTokenType::Bearer)

--- a/examples/wunderlist.rs
+++ b/examples/wunderlist.rs
@@ -14,7 +14,10 @@
 //! ...and follow the instructions.
 //!
 
-use oauth2::basic::{BasicErrorResponse, BasicRevocableToken, BasicRevocationErrorResponse, BasicTokenIntrospectionResponse, BasicTokenType};
+use oauth2::basic::{
+    BasicErrorResponse, BasicRevocableToken, BasicRevocationErrorResponse,
+    BasicTokenIntrospectionResponse, BasicTokenType,
+};
 use oauth2::TokenType;
 // Alternatively, this can be `oauth2::curl::http_client` or a custom client.
 use oauth2::helpers;
@@ -40,7 +43,7 @@ type SpecialClient = Client<
     SpecialTokenResponse,
     BasicTokenType,
     BasicTokenIntrospectionResponse,
-    BasicRevocationErrorResponse
+    BasicRevocationErrorResponse,
 >;
 
 fn default_token_type() -> Option<BasicTokenType> {

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -14,11 +14,11 @@ use crate::{
 /// Basic OAuth2 client specialization, suitable for most applications.
 ///
 pub type BasicClient = Client<
-    StandardRevocableToken,
     BasicErrorResponse,
     BasicTokenResponse,
     BasicTokenType,
     BasicTokenIntrospectionResponse,
+    StandardRevocableToken,
     BasicRevocationErrorResponse,
 >;
 

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -5,10 +5,7 @@ use super::{
     Client, EmptyExtraTokenFields, ErrorResponseType, RequestTokenError, StandardErrorResponse,
     StandardTokenResponse, TokenType,
 };
-use crate::{
-    revocation::{RevocationErrorResponse, StandardRevocableToken},
-    StandardTokenIntrospectionResponse,
-};
+use crate::{StandardTokenIntrospectionResponse, revocation::{RevocationErrorResponseType, StandardRevocableToken}};
 
 ///
 /// Basic OAuth2 client specialization, suitable for most applications.
@@ -207,4 +204,4 @@ pub type BasicRequestTokenError<RE> = RequestTokenError<RE, BasicErrorResponse>;
 ///
 ///
 ///
-pub type BasicRevocationErrorResponse = RevocationErrorResponse;
+pub type BasicRevocationErrorResponse = StandardErrorResponse<RevocationErrorResponseType>;

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -5,13 +5,13 @@ use super::{
     Client, EmptyExtraTokenFields, ErrorResponseType, RequestTokenError, StandardErrorResponse,
     StandardTokenResponse, TokenType,
 };
-use crate::StandardTokenInspectionResponse;
+use crate::{StandardTokenInspectionResponse, revocation::{RevocationErrorResponse, StandardRevocableToken}};
 
 ///
 /// Basic OAuth2 client specialization, suitable for most applications.
 ///
 pub type BasicClient =
-    Client<BasicErrorResponse, BasicTokenResponse, BasicTokenType, BasicTokenInspectionResponse>;
+    Client<BasicRevocableToken, BasicErrorResponse, BasicTokenResponse, BasicTokenType, BasicTokenInspectionResponse, BasicRevocationErrorResponse>;
 
 ///
 /// Basic OAuth2 authorization token types.
@@ -80,6 +80,11 @@ pub type BasicTokenResponse = StandardTokenResponse<EmptyExtraTokenFields, Basic
 ///
 pub type BasicTokenInspectionResponse =
     StandardTokenInspectionResponse<EmptyExtraTokenFields, BasicTokenType>;
+
+///
+/// Basic OAuth2 revocable token type
+///
+pub type BasicRevocableToken = StandardRevocableToken;
 
 ///
 /// Basic access token error types.
@@ -189,3 +194,8 @@ pub type BasicErrorResponse = StandardErrorResponse<BasicErrorResponseType>;
 /// Token error specialization for basic OAuth2 implementation.
 ///
 pub type BasicRequestTokenError<RE> = RequestTokenError<RE, BasicErrorResponse>;
+
+///
+///
+///
+pub type BasicRevocationErrorResponse = RevocationErrorResponse;

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -5,13 +5,22 @@ use super::{
     Client, EmptyExtraTokenFields, ErrorResponseType, RequestTokenError, StandardErrorResponse,
     StandardTokenResponse, TokenType,
 };
-use crate::{StandardTokenIntrospectionResponse, revocation::{RevocationErrorResponse, StandardRevocableToken}};
+use crate::{
+    revocation::{RevocationErrorResponse, StandardRevocableToken},
+    StandardTokenIntrospectionResponse,
+};
 
 ///
 /// Basic OAuth2 client specialization, suitable for most applications.
 ///
-pub type BasicClient =
-    Client<BasicRevocableToken, BasicErrorResponse, BasicTokenResponse, BasicTokenType, BasicTokenIntrospectionResponse, BasicRevocationErrorResponse>;
+pub type BasicClient = Client<
+    BasicRevocableToken,
+    BasicErrorResponse,
+    BasicTokenResponse,
+    BasicTokenType,
+    BasicTokenIntrospectionResponse,
+    BasicRevocationErrorResponse,
+>;
 
 ///
 /// Basic OAuth2 authorization token types.

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -5,13 +5,16 @@ use super::{
     Client, EmptyExtraTokenFields, ErrorResponseType, RequestTokenError, StandardErrorResponse,
     StandardTokenResponse, TokenType,
 };
-use crate::{StandardTokenIntrospectionResponse, revocation::{RevocationErrorResponseType, StandardRevocableToken}};
+use crate::{
+    revocation::{RevocationErrorResponseType, StandardRevocableToken},
+    StandardTokenIntrospectionResponse,
+};
 
 ///
 /// Basic OAuth2 client specialization, suitable for most applications.
 ///
 pub type BasicClient = Client<
-    BasicRevocableToken,
+    StandardRevocableToken,
     BasicErrorResponse,
     BasicTokenResponse,
     BasicTokenType,
@@ -86,11 +89,6 @@ pub type BasicTokenResponse = StandardTokenResponse<EmptyExtraTokenFields, Basic
 ///
 pub type BasicTokenIntrospectionResponse =
     StandardTokenIntrospectionResponse<EmptyExtraTokenFields, BasicTokenType>;
-
-///
-/// Basic OAuth2 revocable token type
-///
-pub type BasicRevocableToken = StandardRevocableToken;
 
 ///
 /// Basic access token error types.

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -200,6 +200,6 @@ pub type BasicErrorResponse = StandardErrorResponse<BasicErrorResponseType>;
 pub type BasicRequestTokenError<RE> = RequestTokenError<RE, BasicErrorResponse>;
 
 ///
-///
+/// Revocation error response specialization for basic OAuth2 implementation.
 ///
 pub type BasicRevocationErrorResponse = StandardErrorResponse<RevocationErrorResponseType>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -848,8 +848,12 @@ where
     }
 
     ///
-    /// Query the authorization server [`RFC 7662 compatible`](https://tools.ietf.org/html/rfc7662) endpoint to
-    /// determine the set of metadata for a given previously received token.
+    /// Exchanges a code produced by a successful authorization process with an access token.
+    ///
+    /// Acquires ownership of the `code` because authorization codes may only be used once to
+    /// retrieve an access token from the authorization server.
+    ///
+    /// See https://tools.ietf.org/html/rfc6749#section-4.1.3
     ///
     pub fn introspect<'a>(&'a self, token: &'a AccessToken) -> IntrospectRequest<'a, TE, TIR, TT> {
         IntrospectRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -855,8 +855,7 @@ where
     ///
     /// See https://tools.ietf.org/html/rfc7009
     ///
-    pub fn revoke_token<'a>(&'a self, token: RT) -> RevocationRequest<'a, RT, RER>
-    {
+    pub fn revoke_token(&self, token: RT) -> RevocationRequest<RT, RER> {
         RevocationRequest {
             auth_type: &self.auth_type,
             client_id: &self.client_id,
@@ -1697,7 +1696,10 @@ where
     ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
-    pub fn request<F, RE, EF>(self, http_client: F) -> Result<RevocationResponse<EF>, RequestTokenError<RE, TE>>
+    pub fn request<F, RE, EF>(
+        self,
+        http_client: F,
+    ) -> Result<RevocationResponse<EF>, RequestTokenError<RE, TE>>
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
         RE: Error + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,12 +549,7 @@ where
     introspect_url: Option<IntrospectUrl>,
     revocation_url: Option<RevocationUrl>,
     device_authorization_url: Option<DeviceAuthorizationUrl>,
-    phantom_rer: PhantomData<RER>,
-    phantom_rt: PhantomData<RT>,
-    phantom_te: PhantomData<TE>,
-    phantom_tr: PhantomData<TR>,
-    phantom_tt: PhantomData<TT>,
-    phantom_tir: PhantomData<TIR>,
+    phantom: PhantomData<(RER, RT, TE, TR, TT, TIR)>,
 }
 
 impl<RT, TE, TR, TT, TIR, RER> Client<RT, TE, TR, TT, TIR, RER>
@@ -602,12 +597,7 @@ where
             introspect_url: None,
             revocation_url: None,
             device_authorization_url: None,
-            phantom_rer: PhantomData,
-            phantom_rt: PhantomData,
-            phantom_te: PhantomData,
-            phantom_tr: PhantomData,
-            phantom_tt: PhantomData,
-            phantom_tir: PhantomData,
+            phantom: PhantomData,
         }
     }
 
@@ -1649,7 +1639,7 @@ where
     TE: ErrorResponse + 'static,
 {
     ///
-    /// Appends an extra param to the token introspect.
+    /// Appends an extra param to the token revocation request.
     ///
     /// This method allows extensions to be used without direct support from
     /// this crate. If `name` conflicts with a parameter managed by this crate, the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ pub use types::{
     ResourceOwnerUsername, ResponseType, RevocationUrl, Scope, TokenUrl, UserCode,
 };
 
-use crate::revocation::RevocableToken;
+pub use crate::revocation::RevocableToken;
 
 const CONTENT_TYPE_JSON: &str = "application/json";
 const CONTENT_TYPE_FORMENCODED: &str = "application/x-www-form-urlencoded";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,7 +652,9 @@ where
     }
 
     ///
-    /// Sets the introspect URL used by the introspect endpoint.
+    /// Sets the introspect URL for contacting the introspect endpoint ([RFC 7662](https://tools.ietf.org/html/rfc7662)).
+    ///
+    /// See: [`introspect()`](Self::introspect())
     ///
     pub fn set_introspection_url(mut self, introspect_url: IntrospectUrl) -> Self {
         self.introspect_url = Some(introspect_url);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,9 +652,7 @@ where
     }
 
     ///
-    /// Sets the introspect URL for contacting the introspect endpoint ([RFC 7662](https://tools.ietf.org/html/rfc7662)).
-    ///
-    /// See: [`introspect()`](Self::introspect())
+    /// Sets the introspect URL used by the introspect endpoint.
     ///
     pub fn set_introspection_url(mut self, introspect_url: IntrospectUrl) -> Self {
         self.introspect_url = Some(introspect_url);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,14 +531,14 @@ pub enum AuthType {
 /// Stores the configuration for an OAuth2 client.
 ///
 #[derive(Clone, Debug)]
-pub struct Client<RT, TE, TR, TT, TIR, RER>
+pub struct Client<TE, TR, TT, TIR, RT, RTE>
 where
-    RT: RevocableToken,
     TE: ErrorResponse,
     TR: TokenResponse<TT>,
     TT: TokenType,
     TIR: TokenIntrospectionResponse<TT>,
-    RER: ErrorResponse,
+    RT: RevocableToken,
+    RTE: ErrorResponse,
 {
     client_id: ClientId,
     client_secret: Option<ClientSecret>,
@@ -549,17 +549,17 @@ where
     introspect_url: Option<IntrospectUrl>,
     revocation_url: Option<RevocationUrl>,
     device_authorization_url: Option<DeviceAuthorizationUrl>,
-    phantom: PhantomData<(RER, RT, TE, TR, TT, TIR)>,
+    phantom: PhantomData<(TE, TR, TT, TIR, RT, RTE)>,
 }
 
-impl<RT, TE, TR, TT, TIR, RER> Client<RT, TE, TR, TT, TIR, RER>
+impl<TE, TR, TT, TIR, RT, RTE> Client<TE, TR, TT, TIR, RT, RTE>
 where
-    RT: RevocableToken,
     TE: ErrorResponse + 'static,
     TR: TokenResponse<TT>,
     TT: TokenType,
     TIR: TokenIntrospectionResponse<TT>,
-    RER: ErrorResponse + 'static,
+    RT: RevocableToken,
+    RTE: ErrorResponse + 'static,
 {
     ///
     /// Initializes an OAuth2 client with the fields common to most OAuth2 flows.
@@ -845,7 +845,7 @@ where
     ///
     /// See https://tools.ietf.org/html/rfc7009
     ///
-    pub fn revoke_token(&self, token: RT) -> RevocationRequest<RT, RER> {
+    pub fn revoke_token(&self, token: RT) -> RevocationRequest<RT, RTE> {
         RevocationRequest {
             auth_type: &self.auth_type,
             client_id: &self.client_id,

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -1,4 +1,4 @@
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::fmt::Error as FormatterError;
 use std::fmt::{Debug, Display, Formatter};
 
@@ -55,6 +55,30 @@ impl RevocableToken for StandardRevocableToken {
             StandardRevocableToken::AccessToken(_) => "access_token",
             StandardRevocableToken::RefreshToken(_) => "refresh_token",
         }
+    }
+}
+
+impl From<AccessToken> for StandardRevocableToken {
+    fn from(token: AccessToken) -> Self {
+        Self::AccessToken(token)
+    }
+}
+
+impl From<&AccessToken> for StandardRevocableToken {
+    fn from(token: &AccessToken) -> Self {
+        Self::AccessToken(token.clone())
+    }
+}
+
+impl From<RefreshToken> for StandardRevocableToken {
+    fn from(token: RefreshToken) -> Self {
+        Self::RefreshToken(token)
+    }
+}
+
+impl From<&RefreshToken> for StandardRevocableToken {
+    fn from(token: &RefreshToken) -> Self {
+        Self::RefreshToken(token.clone())
     }
 }
 
@@ -127,33 +151,3 @@ impl Display for RevocationErrorResponseType {
         write!(f, "{}", self.as_ref())
     }
 }
-
-///
-/// Standard OAuth2 token revocation response.
-///
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct RevocationResponse<EF>
-where
-    EF: ExtraRevocationResponseFields,
-{
-    #[serde(bound = "EF: ExtraRevocationResponseFields", flatten)]
-    extra_fields: EF,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-///
-/// Empty (default) extra token fields.
-///
-pub struct EmptyExtraRevocationResponseFields {}
-impl ExtraRevocationResponseFields for EmptyExtraRevocationResponseFields {}
-
-///
-/// Trait for adding extra fields to the `RevocationResponse`.
-///
-pub trait ExtraRevocationResponseFields: DeserializeOwned + Debug + Serialize {}
-
-///
-/// Standard implementation of RevocationResponse which throws away
-/// extra received response fields.
-///
-pub type StandardRevocationResponse = RevocationResponse<EmptyExtraRevocationResponseFields>;

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -26,29 +26,13 @@ impl RevocableToken for StandardRevocableToken {
     }
 
     ///
-    /// Indicate the type of the token.
+    /// Indicates the type of the token to be revoked, as defined by [RFC 7009, Section 2.1](https://tools.ietf.org/html/rfc7009#section-2.1), i.e.:
     ///
-    /// See: https://tools.ietf.org/html/rfc7009#section-2.1
-    ///
-    /// OPTIONAL.  A hint about the type of the token
-    /// submitted for revocation.  Clients MAY pass this parameter in
-    /// order to help the authorization server to optimize the token
-    /// lookup.  If the server is unable to locate the token using
-    /// the given hint, it MUST extend its search across all of its
-    /// supported token types.  An authorization server MAY ignore
-    /// this parameter, particularly if it is able to detect the
-    /// token type automatically.  This specification defines two
-    /// such values:
-    ///
-    /// * access_token: An access token as defined in [[RFC6749],
+    /// * `access_token`: An access token as defined in [RFC 6749,
     ///   Section 1.4](https://tools.ietf.org/html/rfc6749#section-1.4)
     ///
-    /// * refresh_token: A refresh token as defined in [[RFC6749],
+    /// * `refresh_token`: A refresh token as defined in [RFC 6749,
     ///   Section 1.5](https://tools.ietf.org/html/rfc6749#section-1.5)
-    ///
-    /// Specific implementations, profiles, and extensions of this
-    /// specification MAY define other values for this parameter
-    /// using the registry defined in [Section 4.1.2](https://tools.ietf.org/html/rfc6749#section-4.1.2).
     ///
     fn token_type_hint(&self) -> &str {
         match self {

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -2,13 +2,13 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::Error as FormatterError;
 use std::fmt::{Debug, Display, Formatter};
 
-use crate::{basic::BasicErrorResponseType, ErrorResponseType, StandardErrorResponse};
+use crate::{basic::BasicErrorResponseType, ErrorResponseType};
 use crate::{AccessToken, RefreshToken};
 
 pub trait RevocableToken {
-    fn secret(&self) -> &String;
+    fn secret(&self) -> &str;
 
-    fn token_type_hint(&self) -> &'static str;
+    fn token_type_hint(&self) -> &str;
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17,7 +17,7 @@ pub enum StandardRevocableToken {
     RefreshToken(RefreshToken),
 }
 impl RevocableToken for StandardRevocableToken {
-    fn secret(&self) -> &String {
+    fn secret(&self) -> &str {
         match self {
             Self::AccessToken(token) => token.secret(),
             Self::RefreshToken(token) => token.secret(),
@@ -49,7 +49,7 @@ impl RevocableToken for StandardRevocableToken {
     /// specification MAY define other values for this parameter
     /// using the registry defined in [Section 4.1.2](https://tools.ietf.org/html/rfc6749#section-4.1.2).
     ///
-    fn token_type_hint(&self) -> &'static str {
+    fn token_type_hint(&self) -> &str {
         match self {
             StandardRevocableToken::AccessToken(_) => "access_token",
             StandardRevocableToken::RefreshToken(_) => "refresh_token",
@@ -126,11 +126,6 @@ impl Display for RevocationErrorResponseType {
         write!(f, "{}", self.as_ref())
     }
 }
-
-///
-/// Error response specialization for device code OAuth2 implementation.
-///
-pub type RevocationErrorResponse = StandardErrorResponse<RevocationErrorResponseType>;
 
 ///
 /// Standard OAuth2 token revocation response.

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -1,0 +1,163 @@
+use std::fmt::Error as FormatterError;
+use std::fmt::{Debug, Display, Formatter};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+use crate::{ErrorResponseType, StandardErrorResponse, basic::BasicErrorResponseType};
+use crate::{AccessToken, RefreshToken};
+
+pub trait RevocableToken {
+    fn secret(&self) -> &String;
+
+    fn token_type_hint(&self) -> &'static str;
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum StandardRevocableToken {
+    AccessToken(AccessToken),
+    RefreshToken(RefreshToken),
+}
+impl RevocableToken for StandardRevocableToken {
+    fn secret(&self) -> &String {
+        match self {
+            Self::AccessToken(token) => token.secret(),
+            Self::RefreshToken(token) => token.secret(),
+        }
+    }
+
+    ///
+    /// Indicate the type of the token.
+    ///
+    /// See: https://tools.ietf.org/html/rfc7009#section-2.1
+    ///
+    /// OPTIONAL.  A hint about the type of the token
+    /// submitted for revocation.  Clients MAY pass this parameter in
+    /// order to help the authorization server to optimize the token
+    /// lookup.  If the server is unable to locate the token using
+    /// the given hint, it MUST extend its search across all of its
+    /// supported token types.  An authorization server MAY ignore
+    /// this parameter, particularly if it is able to detect the
+    /// token type automatically.  This specification defines two
+    /// such values:
+    ///
+    /// * access_token: An access token as defined in [[RFC6749],
+    ///   Section 1.4](https://tools.ietf.org/html/rfc6749#section-1.4)
+    ///
+    /// * refresh_token: A refresh token as defined in [[RFC6749],
+    ///   Section 1.5](https://tools.ietf.org/html/rfc6749#section-1.5)
+    /// 
+    /// Specific implementations, profiles, and extensions of this
+    /// specification MAY define other values for this parameter
+    /// using the registry defined in [Section 4.1.2](https://tools.ietf.org/html/rfc6749#section-4.1.2).
+    ///
+    fn token_type_hint(&self) -> &'static str {
+        match self {
+            StandardRevocableToken::AccessToken(_) => "access_token",
+            StandardRevocableToken::RefreshToken(_) => "refresh_token",
+        }
+    }
+}
+
+///
+/// OAuth 2.0 Token Revocation error response types
+///
+/// These error types are defined in
+/// [Section 2.2.1 of RFC 7009](https://tools.ietf.org/html/rfc7009#section-2.2.1) and
+/// [Section 5.2 of RFC 6749](https://tools.ietf.org/html/rfc8628#section-5.2)
+///
+#[derive(Clone, PartialEq)]
+pub enum RevocationErrorResponseType {
+    ///
+    /// The authorization server does not support
+    /// the revocation of the presented token type.  That is, the
+    /// client tried to revoke an access token on a server not
+    /// supporting this feature.
+    ///
+    UnsupportedTokenType,
+    ///
+    /// A Basic response type
+    ///
+    Basic(BasicErrorResponseType),
+}
+impl RevocationErrorResponseType {
+    fn from_str(s: &str) -> Self {
+        match BasicErrorResponseType::from_str(s) {
+            BasicErrorResponseType::Extension(ext) => match ext.as_str() {
+                "unsupported_token_type" => RevocationErrorResponseType::UnsupportedTokenType,
+                _ => RevocationErrorResponseType::Basic(BasicErrorResponseType::Extension(ext)),
+            },
+            basic => RevocationErrorResponseType::Basic(basic),
+        }
+    }
+}
+impl AsRef<str> for RevocationErrorResponseType {
+    fn as_ref(&self) -> &str {
+        match self {
+            RevocationErrorResponseType::UnsupportedTokenType => "unsupported_token_type",
+            RevocationErrorResponseType::Basic(basic) => basic.as_ref(),
+        }
+    }
+}
+impl<'de> serde::Deserialize<'de> for RevocationErrorResponseType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let variant_str = String::deserialize(deserializer)?;
+        Ok(Self::from_str(&variant_str))
+    }
+}
+impl serde::ser::Serialize for RevocationErrorResponseType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_str(self.as_ref())
+    }
+}
+impl ErrorResponseType for RevocationErrorResponseType {}
+impl Debug for RevocationErrorResponseType {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatterError> {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for RevocationErrorResponseType {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatterError> {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+///
+/// Error response specialization for device code OAuth2 implementation.
+///
+pub type RevocationErrorResponse = StandardErrorResponse<RevocationErrorResponseType>;
+
+///
+/// Standard OAuth2 token revocation response.
+///
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RevocationResponse<EF>
+where
+    EF: ExtraRevocationResponseFields,
+{
+    #[serde(bound = "EF: ExtraRevocationResponseFields", flatten)]
+    extra_fields: EF,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+///
+/// Empty (default) extra token fields.
+///
+pub struct EmptyExtraRevocationResponseFields {}
+impl ExtraRevocationResponseFields for EmptyExtraRevocationResponseFields {}
+
+///
+/// Trait for adding extra fields to the `RevocationResponse`.
+///
+pub trait ExtraRevocationResponseFields: DeserializeOwned + Debug + Serialize {}
+
+///
+/// Standard implementation of RevocationResponse which throws away
+/// extra received response fields.
+///
+pub type StandardRevocationResponse = RevocationResponse<EmptyExtraRevocationResponseFields>;

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -1,8 +1,8 @@
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::fmt::Error as FormatterError;
 use std::fmt::{Debug, Display, Formatter};
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::{ErrorResponseType, StandardErrorResponse, basic::BasicErrorResponseType};
+use crate::{basic::BasicErrorResponseType, ErrorResponseType, StandardErrorResponse};
 use crate::{AccessToken, RefreshToken};
 
 pub trait RevocableToken {
@@ -44,7 +44,7 @@ impl RevocableToken for StandardRevocableToken {
     ///
     /// * refresh_token: A refresh token as defined in [[RFC6749],
     ///   Section 1.5](https://tools.ietf.org/html/rfc6749#section-1.5)
-    /// 
+    ///
     /// Specific implementations, profiles, and extensions of this
     /// specification MAY define other values for this parameter
     /// using the registry defined in [Section 4.1.2](https://tools.ietf.org/html/rfc6749#section-4.1.2).

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -33,7 +33,7 @@ pub trait RevocableToken {
 ///
 /// Automatically reports the correct RFC 7009 [`token_type_hint`](https://tools.ietf.org/html/rfc7009#section-2.1) value corresponding to the token type variant used, i.e.
 /// `access_token` for [`AccessToken`] and `secret_token` for [`RefreshToken`].
-/// 
+///
 /// # Example
 ///
 /// Per [RFC 7009, Section 2](https://tools.ietf.org/html/rfc7009#section-2) prefer revocation by refresh token which,
@@ -45,7 +45,7 @@ pub trait RevocableToken {
 ///     Some(token) => token.into(),
 ///     None => token_response.access_token().into(),
 /// };
-/// 
+///
 /// client
 ///     .revoke_token(token_to_revoke)
 ///     .request(http_client)

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -5,16 +5,61 @@ use std::fmt::{Debug, Display, Formatter};
 use crate::{basic::BasicErrorResponseType, ErrorResponseType};
 use crate::{AccessToken, RefreshToken};
 
+///
+/// A revocable token.
+///
+/// Implement this trait to indicate support for token revocation per [RFC 7009 OAuth 2.0 Token Revocation](https://tools.ietf.org/html/rfc7009#section-2.2).
+///
 pub trait RevocableToken {
+    ///
+    /// The actual token value to be revoked.
+    ///
     fn secret(&self) -> &str;
 
-    fn token_type_hint(&self) -> &str;
+    ///
+    /// Indicates the type of the token being revoked, as defined by [RFC 7009, Section 2.1](https://tools.ietf.org/html/rfc7009#section-2.1).
+    ///
+    /// Implementations should return `Some(...)` values for token types that the target authorization servers are
+    /// expected to know (e.g. because they are registered in the [OAuth Token Type Hints Registry](https://tools.ietf.org/html/rfc7009#section-4.1.2)
+    /// so that they can potentially optimize their search for the token to be revoked.
+    ///
+    fn type_hint(&self) -> Option<&str>;
 }
 
+///
+/// A token representation usable with authorization servers that support [RFC 7009](https://tools.ietf.org/html/rfc7009) token revocation.
+///
+/// For use with [`revoke_token()`].
+///
+/// Automatically reports the correct RFC 7009 [`token_type_hint`](https://tools.ietf.org/html/rfc7009#section-2.1) value corresponding to the token type variant used, i.e.
+/// `access_token` for [`AccessToken`] and `secret_token` for [`RefreshToken`].
+/// 
+/// # Example
+///
+/// Per [RFC 7009, Section 2](https://tools.ietf.org/html/rfc7009#section-2) prefer revocation by refresh token which,
+/// if issued to the client, must be supported by the server, otherwise fallback to access token (which may or may not
+/// be supported by the server).
+///
+/// ```ignore
+/// let token_to_revoke: StandardRevocableToken = match token_response.refresh_token() {
+///     Some(token) => token.into(),
+///     None => token_response.access_token().into(),
+/// };
+/// 
+/// client
+///     .revoke_token(token_to_revoke)
+///     .request(http_client)
+///     .unwrap();
+/// ```
+///
+/// [`revoke_token()`]: crate::Client::revoke_token()
+///
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub enum StandardRevocableToken {
+    /// A representation of an [`AccessToken`] suitable for use with [`revoke_token()`](crate::Client::revoke_token()).
     AccessToken(AccessToken),
+    /// A representation of an [`RefreshToken`] suitable for use with [`revoke_token()`](crate::Client::revoke_token()).
     RefreshToken(RefreshToken),
 }
 impl RevocableToken for StandardRevocableToken {
@@ -34,10 +79,10 @@ impl RevocableToken for StandardRevocableToken {
     /// * `refresh_token`: A refresh token as defined in [RFC 6749,
     ///   Section 1.5](https://tools.ietf.org/html/rfc6749#section-1.5)
     ///
-    fn token_type_hint(&self) -> &str {
+    fn type_hint(&self) -> Option<&str> {
         match self {
-            StandardRevocableToken::AccessToken(_) => "access_token",
-            StandardRevocableToken::RefreshToken(_) => "refresh_token",
+            StandardRevocableToken::AccessToken(_) => Some("access_token"),
+            StandardRevocableToken::RefreshToken(_) => Some("refresh_token"),
         }
     }
 }
@@ -67,7 +112,7 @@ impl From<&RefreshToken> for StandardRevocableToken {
 }
 
 ///
-/// OAuth 2.0 Token Revocation error response types
+/// OAuth 2.0 Token Revocation error response types.
 ///
 /// These error types are defined in
 /// [Section 2.2.1 of RFC 7009](https://tools.ietf.org/html/rfc7009#section-2.2.1) and
@@ -76,14 +121,11 @@ impl From<&RefreshToken> for StandardRevocableToken {
 #[derive(Clone, PartialEq)]
 pub enum RevocationErrorResponseType {
     ///
-    /// The authorization server does not support
-    /// the revocation of the presented token type.  That is, the
-    /// client tried to revoke an access token on a server not
-    /// supporting this feature.
+    /// The authorization server does not support the revocation of the presented token type.
     ///
     UnsupportedTokenType,
     ///
-    /// A Basic response type
+    /// The authorization server responded with some other error as defined [RFC 6749](https://tools.ietf.org/html/rfc6749) error.
     ///
     Basic(BasicErrorResponseType),
 }

--- a/src/revocation.rs
+++ b/src/revocation.rs
@@ -12,6 +12,7 @@ pub trait RevocableToken {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub enum StandardRevocableToken {
     AccessToken(AccessToken),
     RefreshToken(RefreshToken),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 use http::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use http::status::StatusCode;
+use revocation::{StandardRevocableToken, StandardRevocationResponse};
 use thiserror::Error;
 use url::form_urlencoded::byte_serialize;
 use url::Url;
@@ -1080,10 +1081,12 @@ mod colorful_extension {
     use std::fmt::{Debug, Display, Formatter};
 
     pub type ColorfulClient = Client<
+        ColorfulRevocableToken,
         StandardErrorResponse<ColorfulErrorResponseType>,
         StandardTokenResponse<ColorfulFields, ColorfulTokenType>,
         ColorfulTokenType,
         StandardTokenIntrospectionResponse<ColorfulFields, ColorfulTokenType>,
+        StandardErrorResponse<ColorfulErrorResponseType>
     >;
 
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -1147,6 +1150,26 @@ mod colorful_extension {
     }
 
     pub type ColorfulTokenResponse = StandardTokenResponse<ColorfulFields, ColorfulTokenType>;
+
+    pub enum ColorfulRevocableToken {
+        Red(String),
+        Blue(String),
+    }
+    impl RevocableToken for ColorfulRevocableToken {
+        fn secret(&self) -> &String {
+            match self {
+                ColorfulRevocableToken::Red(secret) => &secret,
+                ColorfulRevocableToken::Blue(secret) => &secret,
+            }
+        }
+
+        fn token_type_hint(&self) -> &'static str {
+            match self {
+                ColorfulRevocableToken::Red(_) => "red",
+                ColorfulRevocableToken::Blue(_) => "blue",
+            }
+        }
+    }
 }
 
 #[test]
@@ -1372,10 +1395,12 @@ mod custom_errors {
     impl ErrorResponse for CustomErrorResponse {}
 
     pub type CustomErrorClient = Client<
+        ColorfulRevocableToken,
         CustomErrorResponse,
         StandardTokenResponse<ColorfulFields, ColorfulTokenType>,
         ColorfulTokenType,
         StandardTokenIntrospectionResponse<ColorfulFields, ColorfulTokenType>,
+        CustomErrorResponse,
     >;
 }
 
@@ -2134,10 +2159,12 @@ fn test_send_sync_impl() {
     is_sync_and_send::<AuthorizationRequest>();
     is_sync_and_send::<
         Client<
+            BasicRevocableToken,
             StandardErrorResponse<BasicErrorResponseType>,
             StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
             BasicTokenType,
             StandardTokenIntrospectionResponse<EmptyExtraTokenFields, BasicTokenType>,
+            BasicRevocationErrorResponse,
         >,
     >();
     is_sync_and_send::<

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,11 @@
 use http::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use http::status::StatusCode;
+use revocation::RevocationErrorResponseType;
 use thiserror::Error;
 use url::form_urlencoded::byte_serialize;
 use url::Url;
+
+use crate::revocation::StandardRevocableToken;
 
 use super::basic::*;
 use super::devicecode::*;
@@ -1152,20 +1155,17 @@ mod colorful_extension {
 
     pub enum ColorfulRevocableToken {
         Red(String),
-        Blue(String),
     }
     impl RevocableToken for ColorfulRevocableToken {
         fn secret(&self) -> &str {
             match self {
                 ColorfulRevocableToken::Red(secret) => &secret,
-                ColorfulRevocableToken::Blue(secret) => &secret,
             }
         }
 
         fn token_type_hint(&self) -> &str {
             match self {
-                ColorfulRevocableToken::Red(_) => "red",
-                ColorfulRevocableToken::Blue(_) => "blue",
+                ColorfulRevocableToken::Red(_) => "red_token",
             }
         }
     }
@@ -1649,6 +1649,117 @@ fn test_token_introspection_successful_with_basic_auth_full_response() {
         Some("be1b7da2-fc18-47b3-bdf1-7a4f50bcf53f".to_string()),
         introspect.jti
     );
+}
+
+#[test]
+fn test_token_revocation_with_missing_url() {
+    let client = new_client();
+
+    type TestError = RequestTokenError<std::fmt::Error, BasicRevocationErrorResponse>;
+    type TestResult = Result<(), TestError>;
+
+    let result: TestResult = client
+        .revoke_token(AccessToken::new("access_token_123".to_string()).into())
+        .request(|_| unreachable!());
+
+    match result {
+        Err(RequestTokenError::Other(msg)) => assert_eq!(msg, "no revocation_url provided"),
+        _ => unreachable!("Expected an error"),
+    };
+}
+
+#[test]
+fn test_token_revocation_with_non_https_url() {
+    let client = new_client();
+
+    type TestError = RequestTokenError<std::fmt::Error, BasicRevocationErrorResponse>;
+    type TestResult = Result<(), TestError>;
+
+    let result: TestResult = client
+        .set_revocation_url(RevocationUrl::new("http://revocation/url".to_string()).unwrap())
+        .revoke_token(AccessToken::new("access_token_123".to_string()).into())
+        .request(|_| unreachable!());
+
+    match result {
+        Err(RequestTokenError::Other(msg)) => assert_eq!(msg, "revocation_url is not HTTPS"),
+        _ => unreachable!("Expected an error"),
+    };
+}
+
+#[test]
+fn test_token_revocation_with_unsupported_token_type() {
+    let client = new_client()
+        .set_revocation_url(RevocationUrl::new("https://revocation/url".to_string()).unwrap());
+
+    let revocation_response = client
+        .revoke_token(AccessToken::new("access_token_123".to_string()).into())
+        .request(mock_http_client(
+            vec![
+                (ACCEPT, "application/json"),
+                (CONTENT_TYPE, "application/x-www-form-urlencoded"),
+                (AUTHORIZATION, "Basic YWFhOmJiYg=="),
+            ],
+            "token=access_token_123&token_type_hint=access_token",
+            Some("https://revocation/url".parse().unwrap()),
+            HttpResponse {
+                status_code: StatusCode::BAD_REQUEST,
+                headers: vec![(
+                    CONTENT_TYPE,
+                    HeaderValue::from_str("application/json").unwrap(),
+                )]
+                .into_iter()
+                .collect(),
+                body: "{\"error\": \"unsupported_token_type\", \"error_description\": \"stuff happened\", \
+                       \"error_uri\": \"https://errors\"}"
+                    .to_string()
+                    .into_bytes(),
+            },
+        ));
+
+    assert!(matches!(revocation_response, Err(
+        RequestTokenError::ServerResponse(
+            BasicRevocationErrorResponse{
+                error: RevocationErrorResponseType::UnsupportedTokenType,
+                ..
+            })
+        )
+    ));
+}
+#[test]
+fn test_extension_token_revocation_successful() {
+    use self::colorful_extension::*;
+    let client = ColorfulClient::new(
+        ClientId::new("aaa".to_string()),
+        Some(ClientSecret::new("bbb".to_string())),
+        AuthUrl::new("https://example.com/auth".to_string()).unwrap(),
+        Some(TokenUrl::new("https://example.com/token".to_string()).unwrap()),
+    )
+    .set_revocation_url(RevocationUrl::new("https://revocation/url".to_string()).unwrap());
+
+    client
+        .revoke_token(ColorfulRevocableToken::Red(
+            "colorful_token_123".to_string(),
+        ))
+        .request(mock_http_client(
+            vec![
+                (ACCEPT, "application/json"),
+                (CONTENT_TYPE, "application/x-www-form-urlencoded"),
+                (AUTHORIZATION, "Basic YWFhOmJiYg=="),
+            ],
+            "token=colorful_token_123&token_type_hint=red_token",
+            Some("https://revocation/url".parse().unwrap()),
+            HttpResponse {
+                status_code: StatusCode::OK,
+                headers: vec![(
+                    CONTENT_TYPE,
+                    HeaderValue::from_str("application/json").unwrap(),
+                )]
+                .into_iter()
+                .collect(),
+                body: b"{}".to_vec(),
+            },
+        ))
+        .unwrap();
 }
 
 #[test]
@@ -2158,7 +2269,7 @@ fn test_send_sync_impl() {
     is_sync_and_send::<AuthorizationRequest>();
     is_sync_and_send::<
         Client<
-            BasicRevocableToken,
+            StandardRevocableToken,
             StandardErrorResponse<BasicErrorResponseType>,
             StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
             BasicTokenType,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,5 @@
 use http::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use http::status::StatusCode;
-use revocation::{StandardRevocableToken, StandardRevocationResponse};
 use thiserror::Error;
 use url::form_urlencoded::byte_serialize;
 use url::Url;
@@ -1086,7 +1085,7 @@ mod colorful_extension {
         StandardTokenResponse<ColorfulFields, ColorfulTokenType>,
         ColorfulTokenType,
         StandardTokenIntrospectionResponse<ColorfulFields, ColorfulTokenType>,
-        StandardErrorResponse<ColorfulErrorResponseType>
+        StandardErrorResponse<ColorfulErrorResponseType>,
     >;
 
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1791,9 +1791,7 @@ fn test_token_revocation_with_access_token_and_empty_response() {
             Some("https://revocation/url".parse().unwrap()),
             HttpResponse {
                 status_code: StatusCode::OK,
-                headers: vec![]
-                .into_iter()
-                .collect(),
+                headers: vec![].into_iter().collect(),
                 body: vec![],
             },
         ))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1083,11 +1083,11 @@ mod colorful_extension {
     use std::fmt::{Debug, Display, Formatter};
 
     pub type ColorfulClient = Client<
-        ColorfulRevocableToken,
         StandardErrorResponse<ColorfulErrorResponseType>,
         StandardTokenResponse<ColorfulFields, ColorfulTokenType>,
         ColorfulTokenType,
         StandardTokenIntrospectionResponse<ColorfulFields, ColorfulTokenType>,
+        ColorfulRevocableToken,
         StandardErrorResponse<ColorfulErrorResponseType>,
     >;
 
@@ -1394,11 +1394,11 @@ mod custom_errors {
     impl ErrorResponse for CustomErrorResponse {}
 
     pub type CustomErrorClient = Client<
-        ColorfulRevocableToken,
         CustomErrorResponse,
         StandardTokenResponse<ColorfulFields, ColorfulTokenType>,
         ColorfulTokenType,
         StandardTokenIntrospectionResponse<ColorfulFields, ColorfulTokenType>,
+        ColorfulRevocableToken,
         CustomErrorResponse,
     >;
 }
@@ -2326,11 +2326,11 @@ fn test_send_sync_impl() {
     is_sync_and_send::<AuthorizationRequest>();
     is_sync_and_send::<
         Client<
-            StandardRevocableToken,
             StandardErrorResponse<BasicErrorResponseType>,
             StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
             BasicTokenType,
             StandardTokenIntrospectionResponse<EmptyExtraTokenFields, BasicTokenType>,
+            StandardRevocableToken,
             BasicRevocationErrorResponse,
         >,
     >();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1163,9 +1163,9 @@ mod colorful_extension {
             }
         }
 
-        fn token_type_hint(&self) -> &str {
+        fn type_hint(&self) -> Option<&str> {
             match self {
-                ColorfulRevocableToken::Red(_) => "red_token",
+                ColorfulRevocableToken::Red(_) => Some("red_token"),
             }
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1751,7 +1751,8 @@ fn test_token_revocation_with_access_token() {
                 .collect(),
                 body: b"{}".to_vec(),
             },
-        )).unwrap();
+        ))
+        .unwrap();
 }
 
 #[test]
@@ -1779,7 +1780,8 @@ fn test_token_revocation_with_refresh_token() {
                 .collect(),
                 body: b"{}".to_vec(),
             },
-        )).unwrap();
+        ))
+        .unwrap();
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1746,7 +1746,7 @@ fn test_token_revocation_with_unsupported_token_type() {
 }
 
 #[test]
-fn test_token_revocation_with_access_token() {
+fn test_token_revocation_with_access_token_and_empty_json_response() {
     let client = new_client()
         .set_revocation_url(RevocationUrl::new("https://revocation/url".to_string()).unwrap());
 
@@ -1769,6 +1769,61 @@ fn test_token_revocation_with_access_token() {
                 .into_iter()
                 .collect(),
                 body: b"{}".to_vec(),
+            },
+        ))
+        .unwrap();
+}
+
+#[test]
+fn test_token_revocation_with_access_token_and_empty_response() {
+    let client = new_client()
+        .set_revocation_url(RevocationUrl::new("https://revocation/url".to_string()).unwrap());
+
+    client
+        .revoke_token(AccessToken::new("access_token_123".to_string()).into())
+        .request(mock_http_client(
+            vec![
+                (ACCEPT, "application/json"),
+                (CONTENT_TYPE, "application/x-www-form-urlencoded"),
+                (AUTHORIZATION, "Basic YWFhOmJiYg=="),
+            ],
+            "token=access_token_123&token_type_hint=access_token",
+            Some("https://revocation/url".parse().unwrap()),
+            HttpResponse {
+                status_code: StatusCode::OK,
+                headers: vec![]
+                .into_iter()
+                .collect(),
+                body: vec![],
+            },
+        ))
+        .unwrap();
+}
+
+#[test]
+fn test_token_revocation_with_access_token_and_non_json_response() {
+    let client = new_client()
+        .set_revocation_url(RevocationUrl::new("https://revocation/url".to_string()).unwrap());
+
+    client
+        .revoke_token(AccessToken::new("access_token_123".to_string()).into())
+        .request(mock_http_client(
+            vec![
+                (ACCEPT, "application/json"),
+                (CONTENT_TYPE, "application/x-www-form-urlencoded"),
+                (AUTHORIZATION, "Basic YWFhOmJiYg=="),
+            ],
+            "token=access_token_123&token_type_hint=access_token",
+            Some("https://revocation/url".parse().unwrap()),
+            HttpResponse {
+                status_code: StatusCode::OK,
+                headers: vec![(
+                    CONTENT_TYPE,
+                    HeaderValue::from_str("application/octet-stream").unwrap(),
+                )]
+                .into_iter()
+                .collect(),
+                body: vec![1, 2, 3],
             },
         ))
         .unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1725,6 +1725,63 @@ fn test_token_revocation_with_unsupported_token_type() {
         )
     ));
 }
+
+#[test]
+fn test_token_revocation_with_access_token() {
+    let client = new_client()
+        .set_revocation_url(RevocationUrl::new("https://revocation/url".to_string()).unwrap());
+
+    client
+        .revoke_token(AccessToken::new("access_token_123".to_string()).into())
+        .request(mock_http_client(
+            vec![
+                (ACCEPT, "application/json"),
+                (CONTENT_TYPE, "application/x-www-form-urlencoded"),
+                (AUTHORIZATION, "Basic YWFhOmJiYg=="),
+            ],
+            "token=access_token_123&token_type_hint=access_token",
+            Some("https://revocation/url".parse().unwrap()),
+            HttpResponse {
+                status_code: StatusCode::OK,
+                headers: vec![(
+                    CONTENT_TYPE,
+                    HeaderValue::from_str("application/json").unwrap(),
+                )]
+                .into_iter()
+                .collect(),
+                body: b"{}".to_vec(),
+            },
+        )).unwrap();
+}
+
+#[test]
+fn test_token_revocation_with_refresh_token() {
+    let client = new_client()
+        .set_revocation_url(RevocationUrl::new("https://revocation/url".to_string()).unwrap());
+
+    client
+        .revoke_token(RefreshToken::new("refresh_token_123".to_string()).into())
+        .request(mock_http_client(
+            vec![
+                (ACCEPT, "application/json"),
+                (CONTENT_TYPE, "application/x-www-form-urlencoded"),
+                (AUTHORIZATION, "Basic YWFhOmJiYg=="),
+            ],
+            "token=refresh_token_123&token_type_hint=refresh_token",
+            Some("https://revocation/url".parse().unwrap()),
+            HttpResponse {
+                status_code: StatusCode::OK,
+                headers: vec![(
+                    CONTENT_TYPE,
+                    HeaderValue::from_str("application/json").unwrap(),
+                )]
+                .into_iter()
+                .collect(),
+                body: b"{}".to_vec(),
+            },
+        )).unwrap();
+}
+
 #[test]
 fn test_extension_token_revocation_successful() {
     use self::colorful_extension::*;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1155,14 +1155,14 @@ mod colorful_extension {
         Blue(String),
     }
     impl RevocableToken for ColorfulRevocableToken {
-        fn secret(&self) -> &String {
+        fn secret(&self) -> &str {
             match self {
                 ColorfulRevocableToken::Red(secret) => &secret,
                 ColorfulRevocableToken::Blue(secret) => &secret,
             }
         }
 
-        fn token_type_hint(&self) -> &'static str {
+        fn token_type_hint(&self) -> &str {
             match self {
                 ColorfulRevocableToken::Red(_) => "red",
                 ColorfulRevocableToken::Blue(_) => "blue",

--- a/src/types.rs
+++ b/src/types.rs
@@ -355,6 +355,12 @@ new_url_type![
 ];
 new_url_type![
     ///
+    /// URL of the authorization server's RFC 7009 token revocation endpoint.
+    ///
+    RevocationUrl
+];
+new_url_type![
+    ///
     /// URL of the client's device authorization endpoint.
     ///
     DeviceAuthorizationUrl


### PR DESCRIPTION
Initial DRAFT implementation intended for discussion and refinement.

Supports extensible token types for revocation needed to comply with [RFC 7009 Section 2.1](https://tools.ietf.org/html/rfc7009#section-2.1) support for custom token types.

Supports extensible response handling because RFC 7009 Section 2.1 says _"The content of the response body is ignored by the client as all necessary information is conveyed in the response code"_ but Serde requires some response definition. In testing with Google an empty JSON response was returned. If an alternate provider were to return something more in the body this would break the Serde parsing. However, this still assumes that the response is JSON which RFC 7009 does not appear to mandate.

Known issues:
- Breaks existing code that defines a custom client due to the need to extend the custom client type definition to include new types for revocable token and revocation error response. Note: the PR that added token introspection support had the same limitation.
- Only "tested" against Google. The Google API responds with success but this is not proof that the token was actually revoked. 
- Only "tested" with an access token as in initial tests Google did not issue a refresh token.
- Only the "happy" flow has been tested, i.e. correct handling of an HTTP 400 `unsupported_token_type` response has not been tested.
- Documentation comments are missing.
- I'm not sure that I've used the notion of oauth2 crate Basic and Standard types correctly.
- Perhaps a better approach would be to actually ignore the success resposne body as stated in RFC 7009 Section 2.1?
- The `EndpointError` idea mentioned in [openid-connect issue #37](https://github.com/ramosbugs/openidconnect-rs/issues/37) has not been implemented yet.