### PR TITLE
Allow to select reqwest TLS provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,17 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [features]
-default = ["reqwest"]
+default = ["reqwest", "rustls-tls"]
 pkce-plain = []
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 base64 = "0.12"
 thiserror="1.0"
 http = "0.2"
 rand = "0.7"
-reqwest = { version = "0.11", optional = true, features = ["blocking", "rustls-tls"], default-features = false }
+reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9"


### PR DESCRIPTION
Add two Cargo features so we can choose which TLS backend is used by reqwest.