### PR TITLE
Add add_scopes convenience method for many scopes and/or runtime defined

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -991,6 +991,16 @@ impl<'a> AuthorizationRequest<'a> {
     }
 
     ///
+    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    ///
+    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
+        scopes
+            .iter()
+            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
+        self
+    }
+
+    ///
     /// Appends an extra param to the authorization URL.
     ///
     /// This method allows extensions to be used without direct support from
@@ -1318,6 +1328,16 @@ where
     }
 
     ///
+    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    ///
+    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
+        scopes
+            .iter()
+            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
+        self
+    }
+
+    ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
     pub fn request<F, RE>(self, http_client: F) -> Result<TR, RequestTokenError<RE, TE>>
@@ -1431,6 +1451,16 @@ where
     }
 
     ///
+    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    ///
+    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
+        scopes
+            .iter()
+            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
+        self
+    }
+
+    ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
     pub fn request<F, RE>(self, http_client: F) -> Result<TR, RequestTokenError<RE, TE>>
@@ -1540,6 +1570,16 @@ where
     ///
     pub fn add_scope(mut self, scope: Scope) -> Self {
         self.scopes.push(Cow::Owned(scope));
+        self
+    }
+
+    ///
+    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    ///
+    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
+        scopes
+            .iter()
+            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
         self
     }
 
@@ -2076,6 +2116,16 @@ where
     ///
     pub fn add_scope(mut self, scope: Scope) -> Self {
         self.scopes.push(Cow::Owned(scope));
+        self
+    }
+
+    ///
+    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    ///
+    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
+        scopes
+            .iter()
+            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -991,12 +991,13 @@ impl<'a> AuthorizationRequest<'a> {
     }
 
     ///
-    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    /// Appends a collection of scopes to the token request.
     ///
-    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
-        scopes
-            .iter()
-            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
+    pub fn add_scopes<I>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = Scope>,
+    {
+        self.scopes.extend(scopes.into_iter().map(Cow::Owned));
         self
     }
 
@@ -1328,12 +1329,13 @@ where
     }
 
     ///
-    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    /// Appends a collection of scopes to the token request.
     ///
-    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
-        scopes
-            .iter()
-            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
+    pub fn add_scopes<I>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = Scope>,
+    {
+        self.scopes.extend(scopes.into_iter().map(Cow::Owned));
         self
     }
 
@@ -1451,12 +1453,13 @@ where
     }
 
     ///
-    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    /// Appends a collection of scopes to the token request.
     ///
-    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
-        scopes
-            .iter()
-            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
+    pub fn add_scopes<I>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = Scope>,
+    {
+        self.scopes.extend(scopes.into_iter().map(Cow::Owned));
         self
     }
 
@@ -1574,12 +1577,13 @@ where
     }
 
     ///
-    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    /// Appends a collection of scopes to the token request.
     ///
-    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
-        scopes
-            .iter()
-            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
+    pub fn add_scopes<I>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = Scope>,
+    {
+        self.scopes.extend(scopes.into_iter().map(Cow::Owned));
         self
     }
 
@@ -2120,12 +2124,13 @@ where
     }
 
     ///
-    /// Creates a new Scope for each Vector String and appends to the authorization URL.
+    /// Appends a collection of scopes to the token request.
     ///
-    pub fn add_scopes(mut self, scopes: &[String]) -> Self {
-        scopes
-            .iter()
-            .for_each(|s| self.scopes.push(Cow::Owned(Scope::new(s.to_string()))));
+    pub fn add_scopes<I>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = Scope>,
+    {
+        self.scopes.extend(scopes.into_iter().map(Cow::Owned));
         self
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -177,10 +177,13 @@ fn test_authorize_url_with_param() {
 
 #[test]
 fn test_authorize_url_with_scopes() {
-    let scopes = vec!["read".to_string(), "write".to_string()];
+    let scopes = vec![
+        Scope::new("read".to_string()),
+        Scope::new("write".to_string()),
+    ];
     let (url, _) = new_client()
         .authorize_url(|| CsrfToken::new("csrf_token".to_string()))
-        .add_scopes(&scopes)
+        .add_scopes(scopes)
         .url();
 
     assert_eq!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -177,10 +177,10 @@ fn test_authorize_url_with_param() {
 
 #[test]
 fn test_authorize_url_with_scopes() {
+    let scopes = vec!["read".to_string(), "write".to_string()];
     let (url, _) = new_client()
         .authorize_url(|| CsrfToken::new("csrf_token".to_string()))
-        .add_scope(Scope::new("read".to_string()))
-        .add_scope(Scope::new("write".to_string()))
+        .add_scopes(&scopes)
         .url();
 
     assert_eq!(
@@ -190,6 +190,26 @@ fn test_authorize_url_with_scopes() {
              &client_id=aaa\
              &state=csrf_token\
              &scope=read+write"
+        )
+        .unwrap(),
+        url
+    );
+}
+
+#[test]
+fn test_authorize_url_with_one_scope() {
+    let (url, _) = new_client()
+        .authorize_url(|| CsrfToken::new("csrf_token".to_string()))
+        .add_scope(Scope::new("read".to_string()))
+        .url();
+
+    assert_eq!(
+        Url::parse(
+            "https://example.com/auth\
+             ?response_type=code\
+             &client_id=aaa\
+             &state=csrf_token\
+             &scope=read"
         )
         .unwrap(),
         url


### PR DESCRIPTION
This PR allows clients to pass a `&Vec<String>` to add desired `Scope`'s via new `add_scopes` method. When a client has more than one scope to add and knows them at build time, then the current `add_scope` suffices. But if the desired scopes are known at runtime (e.g. Users might click desired scopes from a list of UI check boxes), this method will be useful and less code for them to write.

No new `clippy` warnings and ran `cargo fmt`. Updated existing test to just use a single scope and added new test to use new `add_scopes` method so it is covered.

Was going to create an issue to discuss, but this was small enough to simply open a PR and discussion can happen here. 