### PR TITLE
Add the possibility of having a sequence of strings as scopes

### DIFF
--- a/examples/wunderlist.rs
+++ b/examples/wunderlist.rs
@@ -74,7 +74,7 @@ pub struct NonStandardTokenResponse<EF: ExtraTokenFields> {
     #[serde(skip_serializing_if = "Option::is_none")]
     refresh_token: Option<RefreshToken>,
     #[serde(rename = "scope")]
-    #[serde(deserialize_with = "helpers::deserialize_space_delimited_vec")]
+    #[serde(deserialize_with = "helpers::deserialize_sequence_or_space_delimited_vec")]
     #[serde(serialize_with = "helpers::serialize_space_delimited_vec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2453,7 +2453,7 @@ where
     #[serde(skip_serializing_if = "Option::is_none")]
     refresh_token: Option<RefreshToken>,
     #[serde(rename = "scope")]
-    #[serde(deserialize_with = "helpers::deserialize_space_delimited_vec")]
+    #[serde(deserialize_with = "helpers::deserialize_sequence_or_space_delimited_vec")]
     #[serde(serialize_with = "helpers::serialize_space_delimited_vec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -2686,7 +2686,7 @@ where
 {
     active: bool,
     #[serde(rename = "scope")]
-    #[serde(deserialize_with = "helpers::deserialize_space_delimited_vec")]
+    #[serde(deserialize_with = "helpers::deserialize_sequence_or_space_delimited_vec")]
     #[serde(serialize_with = "helpers::serialize_space_delimited_vec")]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]


### PR DESCRIPTION
Some OAuth2 APIs have a sequence of strings as scope in the _client credentials_ response (e.g.: [Twitch](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#oauth-client-credentials-flow)), which is not supported in the current oauth2-rs state.

This PR just adds the deserialization to this case.
The easiest approach was to create an abstraction `enum` to encapsulate both options during deserialization (and avoid touching Option parsing and Visitor design altogether). The change only affects the deserialization helper.

Not part of the PR:
To be honest, I had a tough time debugging this. Passing a slice, instead of a string, to serde deserialization makes it very annoying to debug since all parsing errors prints the characters as `u8` instead of the _correct_ JSON string and makes the debugging way more cumbersome. In case I keep using this crate I'll probably submit some other PRs to both add examples for move parts (had to reverse engineer the _client credentials_ part to both know what to use and where this bug was) and better error messages.

Thanks for the work on this crate. Saved me quite some time.