### PR TITLE
Don't depend on chrono oldtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1.0"
 sha2 = "0.9"
 ureq = { version = "2", optional = true }
 url = { version = "2.1", features = ["serde"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 serde_path_to_error = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
We don't need the time::Duration type, so we can get rid of the
(deprecated) time 0.1 dependency by disabling the oldtime chrono
feature