### PR TITLE
Await the sleep_fn future in DeviceAccessTokenRequest::request_async

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2326,7 +2326,7 @@ where
             }
 
             // Sleep here using the provided sleep function.
-            sleep_fn(interval);
+            sleep_fn(interval).await;
         }
     }
 


### PR DESCRIPTION
Previously the future returned by the sleep_fn wasn't awaited, such that DeviceAccessTokenRequest::request_async would spam requests to the token endpoint in a tight loop.