### PR TITLE
Fix typo in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! used:
 //!  * **[`reqwest`]**
 //!
-//!    The `reqwest` HTTP client supports both modes. By default, `reqwest` 0.10 is enabled,
+//!    The `reqwest` HTTP client supports both modes. By default, `reqwest` 0.11 is enabled,
 //!    which supports the synchronous and asynchronous `futures` 0.3 APIs.
 //!
 //!    Synchronous client: [`reqwest::http_client`]


### PR DESCRIPTION
I got a bit confused that the docs mentioned reqwest 0.10, fixed it to the correct 0.11