### PR TITLE
Allow non-https token revocation endpoint

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1784,6 +1784,26 @@ fn test_token_revocation_with_non_https_url() {
 }
 
 #[test]
+fn test_token_revocation_unchecked() {
+    let client = new_client();
+
+    client
+        .set_revocation_uri(RevocationUrl::new("https://revocation/url".to_string()).unwrap())
+        .revoke_token_with_unchecked_url(AccessToken::new("access_token_123".to_string()).into())
+        .unwrap();
+}
+
+#[test]
+fn test_token_revocation_unchecked_with_insecure_url() {
+    let client = new_client();
+
+    client
+        .set_revocation_uri(RevocationUrl::new("http://revocation/url".to_string()).unwrap())
+        .revoke_token_with_unchecked_url(AccessToken::new("access_token_123".to_string()).into())
+        .unwrap();
+}
+
+#[test]
 fn test_token_revocation_with_unsupported_token_type() {
     let client = new_client()
         .set_revocation_uri(RevocationUrl::new("https://revocation/url".to_string()).unwrap());


### PR DESCRIPTION
Not sure if this is something you'd want (or if this is how you'd implement it), but the https enforcement for _only_ the token revocation request created a confusing speed bump for me for local development, where my local copy of the oauth server runs without https.

I initially tried to hack around the restriction by constructing a `RevocationRequest` directly, but it has no public constuctors and private fields. I didn't see anywhere I could hook in between there and `endpoint_request`. Which, honestly, is not a criticism. It's pretty cool that it's so hard to hack an insecure request into this!

I just needed my local dev server to work though, so I forked and added it. HTTPS is still enforced for the `client.revoke_token()` method in compliance with RFC 7009, but may be bypassed by calling `client.revoke_token_with_unchecked_url()`. Feel free to close if this is unwanted :)

I guess the question I am left with is, why _don't_ the other token endpoints require HTTPS? <small>(and I guess the answer is probably mine if I actually read the RFCs)</small>

---

edit: as an example of another approach, python authlib's secure transport check function accepts either `https://` or `http://localhost:` uri prefix, and allows disabling it by an `AUTHLIB_INSECURE_TRANSPORT` environment variable:

https://github.com/lepture/authlib/blob/0788d705adc8232434ef497174711f2efce9879f/authlib/common/security.py#L13-L19