### PR TITLE
breaking change: use a helper type to accept static `str`s as well as heap-allocated `String`s in builders and API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oauth2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Florin Lipan <florinlipan@gmail.com>", "David A. Ramos <ramos@cs.stanford.edu>"]
-version = "4.1.1"
+version = "5.0.0"
 license = "MIT/Apache-2.0"
 description = "An extensible, strongly-typed implementation of OAuth2"
 repository = "https://github.com/ramosbugs/oauth2-rs"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,9 +1,9 @@
 use serde::ser::{Impossible, SerializeStructVariant, SerializeTupleVariant};
 use serde::{de, ser};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
 use std::fmt;
 use std::marker::PhantomData;
-use std::borrow::Cow;
 
 ///
 /// Serde case-insensitive deserializer for an untagged `enum`.
@@ -370,9 +370,9 @@ pub fn variant_name<T: Serialize>(t: &T) -> &'static str {
 }
 
 /// Enum for taking static string literals or allocated strings as parameters.
-/// 
+///
 /// Need a `String`? Use `.to_string()`
-/// 
+///
 /// Need a `str`? Use `.as_str()` or `.as_ref()`
 #[derive(Clone)]
 pub enum AsStr {
@@ -380,7 +380,7 @@ pub enum AsStr {
     Static(&'static str),
 
     /// A heap-allocated, dynamic, mutable `String`.
-    Dynamic(String)
+    Dynamic(String),
 }
 impl AsStr {
     /// Convert to a `&str`
@@ -440,7 +440,7 @@ impl AsRef<str> for AsStr {
 impl serde::Serialize for AsStr {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer
+        S: serde::Serializer,
     {
         serializer.serialize_str(self.as_ref())
     }
@@ -448,7 +448,7 @@ impl serde::Serialize for AsStr {
 impl<'de> serde::Deserialize<'de> for AsStr {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>
+        D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer).map(AsStr::Dynamic)
     }


### PR DESCRIPTION
I have refactored parts of the API to accept `str` as well as `String` to reduce unnecessary allocations.

I decided to not use `Cow<'static, str>` and instead made the `AsStr` type in order to implement the `as_str` function for backwards compatibility. Despite backwards-compatibility-aware changes, this may introduce breaking changes for some users, so a major version change would be required for this PR.