### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ curl = { version = "0.4.0", optional = true }
 [dev-dependencies]
 hex = "0.4"
 hmac = "0.12"
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"] }
 anyhow = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 async-std = "1.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 base64 = "0.13"
-thiserror="1.0"
+thiserror = "1.0"
 http = "0.2"
 rand = "0.8"
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = "0.9"
+sha2 = "0.10"
 ureq = { version = "2", optional = true }
 url = { version = "2.1", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
@@ -42,8 +42,8 @@ curl = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 hex = "0.4"
-hmac = "0.11"
-uuid = { version = "0.8", features = ["v4"] }
-anyhow="1.0"
+hmac = "0.12"
+uuid = { version = "1.0", features = ["v4"] }
+anyhow = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 async-std = "1.6.3"

--- a/examples/letterboxd.rs
+++ b/examples/letterboxd.rs
@@ -14,7 +14,7 @@
 //! ```
 
 use hex::ToHex;
-use hmac::{Hmac, Mac, NewMac};
+use hmac::{Hmac, Mac};
 use oauth2::{
     basic::BasicClient, AuthType, AuthUrl, ClientId, ClientSecret, HttpRequest, HttpResponse,
     ResourceOwnerPassword, ResourceOwnerUsername, TokenUrl,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2469,7 +2469,7 @@ fn test_device_token_slowdown_then_success() {
 
 #[test]
 fn test_send_sync_impl() {
-    fn is_sync_and_send<T: Sync + Send>() {};
+    fn is_sync_and_send<T: Sync + Send>() {}
     #[derive(Debug)]
     struct TestError;
     impl std::fmt::Display for TestError {


### PR DESCRIPTION
We use cargo deny to lint our dependencies on my project, sha2 seems is out of date, but I took the opportunity to update the other dev deps. Hopefully this is all still compliant with the MSRV.