### PR TITLE
(breaking): Reduce unnecessary lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ ureq = { version = "2", optional = true }
 url = { version = "2.1", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 serde_path_to_error = "0.1"
+pin-project = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2597,6 +2597,7 @@ fn test_send_sync_impl() {
     is_sync_and_send::<StandardDeviceAuthorizationResponse>();
     is_sync_and_send::<
         DeviceAccessTokenRequest<
+            fn() -> DateTime<Utc>,
             StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
             BasicTokenType,
             EmptyExtraDeviceAuthorizationFields,


### PR DESCRIPTION
Fixes #179 

This PR attempts to reduce unnecessary lifetimes. This is unfortunately at the expense of a little bit more complexity in handling the Futures. This effect could maybe be reduced somewhat with the use of the `futures` crate.

The other significant change here is the change from `Arc<Fn() -> DateTime + 'b>` to a type parameter which reduced the complexity of the future and I believe reduced the complexity of the lifetimes of `DeviceAcessTokenRequest`. However this is a breaking change!