### PR TITLE
ureq::http_client use `send_bytes()` for POST requests, solves #182

### DIFF
--- a/src/ureq.rs
+++ b/src/ureq.rs
@@ -52,7 +52,7 @@ pub fn http_client(request: HttpRequest) -> Result<HttpResponse, Error> {
     }
 
     let response = if let Method::POST = request.method {
-        req.send(&*request.body)
+        req.send_bytes(&request.body)
     } else {
         req.call()
     }


### PR DESCRIPTION

`ureq::Request::send_bytes` takes a byte slice as argument, so ureq knows the size of the payload and would insert a `Content-Length` http header, while `ureq::Request::send` takes a `impl Read` that streams the payload data, thus the `Content-Length` cannot be  calculated beforehand.