### PR TITLE
Implement more From and TryFrom traits

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 use http::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use http::status::StatusCode;
 use revocation::RevocationErrorResponseType;
+use std::convert::TryInto;
 use thiserror::Error;
 use url::form_urlencoded::byte_serialize;
 use url::Url;
@@ -2509,6 +2510,14 @@ fn test_device_token_slowdown_then_success() {
     );
     assert_eq!(None, token.expires_in());
     assert!(token.refresh_token().is_none());
+}
+
+#[test]
+fn test_impl_from_fromstr() {
+    let _: ClientId = "".to_string().into();
+    let _: ClientSecret = "".to_string().into();
+    let _: RedirectUrl = "https://localhost:8080".parse().unwrap();
+    let _: RedirectUrl = "https://localhost:8080".to_string().try_into().unwrap();
 }
 
 #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
-use std::convert::Into;
+use core::convert::TryFrom;
+use core::str::FromStr;
 use std::fmt::Error as FormatterError;
 use std::fmt::{Debug, Formatter};
 use std::ops::Deref;
@@ -94,9 +95,9 @@ macro_rules! new_type {
                 &self.0
             }
         }
-        impl Into<$type> for $name {
-            fn into(self) -> $type {
-                self.0
+        impl From<$type> for $name {
+            fn from(t: $type) -> Self {
+                Self::new(t)
             }
         }
     }
@@ -168,6 +169,11 @@ macro_rules! new_secret_type {
         impl Debug for $name {
             fn fmt(&self, f: &mut Formatter) -> Result<(), FormatterError> {
                 write!(f, concat!(stringify!($name), "([redacted])"))
+            }
+        }
+        impl From<$type> for $name {
+            fn from(t: $type) -> Self {
+                Self::new(t)
             }
         }
     };
@@ -317,6 +323,18 @@ macro_rules! new_url_type {
             }
         }
         impl Eq for $name {}
+        impl TryFrom<String> for $name {
+            type Error = url::ParseError;
+            fn try_from(str: String) -> Result<Self, url::ParseError> {
+                Self::new(str)
+            }
+        }
+        impl FromStr for $name {
+            type Err = url::ParseError;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::new(String::from(s))
+            }
+        }
     };
 }
 


### PR DESCRIPTION
- `From` over `Into` for all new_type, since you then get `Into` for free
- Add `From` to secret types, since it only allows transforms to the
  ecret type, not from it
- Add `FromStr` and `TryFrom` to new_url_type for better ergonomics
