### PR TITLE
Use DeviceCodeErrorResponseType::ExpiredToken for expired Device token

### DIFF
--- a/examples/microsoft_devicecode.rs
+++ b/examples/microsoft_devicecode.rs
@@ -1,0 +1,42 @@
+use oauth2::basic::BasicClient;
+use oauth2::devicecode::StandardDeviceAuthorizationResponse;
+use oauth2::reqwest::async_http_client;
+use oauth2::{AuthUrl, ClientId, DeviceAuthorizationUrl, Scope, TokenUrl};
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let device_auth_url = DeviceAuthorizationUrl::new(
+        "https://login.microsoftonline.com/common/oauth2/v2.0/devicecode".to_string(),
+    )?;
+    let client = BasicClient::new(
+        ClientId::new("client_id".to_string()),
+        None,
+        AuthUrl::new("https://login.microsoftonline.com/common/oauth2/v2.0/authorize".to_string())?,
+        Some(TokenUrl::new(
+            "https://login.microsoftonline.com/common/v2.0/oauth2/token".to_string(),
+        )?),
+    )
+    .set_device_authorization_url(device_auth_url);
+
+    let details: StandardDeviceAuthorizationResponse = client
+        .exchange_device_code()?
+        .add_scope(Scope::new("read".to_string()))
+        .request_async(async_http_client)
+        .await?;
+
+    eprintln!(
+        "Open this URL in your browser:\n{}\nand enter the code: {}",
+        details.verification_uri().to_string(),
+        details.user_code().secret().to_string()
+    );
+
+    let token_result = client
+        .exchange_device_access_token(&details)
+        .request_async(async_http_client, tokio::time::sleep, None)
+        .await;
+
+    eprintln!("Token:{:?}", token_result);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,7 @@
 //! ## Contributed Examples
 //!
 //! - [`actix-web-oauth2`](https://github.com/pka/actix-web-oauth2) (version 2.x of this crate)
+//! - [Microsoft Async Device Code Flow](https://github.com/LorenzoLeonardo/oauth2-rs/blob/main/examples/microsoft_devicecode.rs)
 //!
 use chrono::serde::ts_seconds_option;
 use chrono::{DateTime, Utc};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,6 @@
 //! ## Contributed Examples
 //!
 //! - [`actix-web-oauth2`](https://github.com/pka/actix-web-oauth2) (version 2.x of this crate)
-//! - [Microsoft Async Device Code Flow](https://github.com/LorenzoLeonardo/oauth2-rs/blob/main/examples/microsoft_devicecode.rs)
 //!
 use chrono::serde::ts_seconds_option;
 use chrono::{DateTime, Utc};
@@ -2334,7 +2333,13 @@ where
         loop {
             let now = (*self.time_fn)();
             if now > timeout_dt {
-                break Err(RequestTokenError::Other("Device code expired".to_string()));
+                break Err(RequestTokenError::ServerResponse(
+                    DeviceCodeErrorResponse::new(
+                        DeviceCodeErrorResponseType::ExpiredToken,
+                        Some(String::from("This device code has expired.")),
+                        None,
+                    ),
+                ));
             }
 
             match self.process_response(http_client(self.prepare_request()?), interval) {
@@ -2373,7 +2378,13 @@ where
         loop {
             let now = (*self.time_fn)();
             if now > timeout_dt {
-                break Err(RequestTokenError::Other("Device code expired".to_string()));
+                break Err(RequestTokenError::ServerResponse(
+                    DeviceCodeErrorResponse::new(
+                        DeviceCodeErrorResponseType::ExpiredToken,
+                        Some(String::from("This device code has expired.")),
+                        None,
+                    ),
+                ));
             }
 
             match self.process_response(http_client(self.prepare_request()?).await, interval) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2203,6 +2203,14 @@ fn test_device_token_authorization_timeout() {
         .err()
         .unwrap();
     match token {
+        RequestTokenError::ServerResponse(msg) => assert_eq!(
+            msg,
+            DeviceCodeErrorResponse::new(
+                DeviceCodeErrorResponseType::ExpiredToken,
+                Some(String::from("This device code has expired.")),
+                None,
+            )
+        ),
         RequestTokenError::Other(msg) => assert_eq!(msg, "Device code expired"),
         _ => unreachable!("Error should be an expiry"),
     }


### PR DESCRIPTION
Hello David

I have a PR to fix this issue. Please review