### PR TITLE
Fix serde_path_to_error dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ sha2 = "0.10"
 ureq = { version = "2", optional = true }
 url = { version = "2.1", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
-serde_path_to_error = "0.1"
+serde_path_to_error = "0.1.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
It is expected that `serde_path_to_error::Error` implements `Debug` but that's only the case from 1.0.2 on.