### PR TITLE
Add cancel routine during polling of access token

### DIFF
--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -166,6 +166,10 @@ pub enum DeviceCodeErrorResponseType {
     /// A Basic response type
     ///
     Basic(BasicErrorResponseType),
+    ///
+    /// Polling for access token was cancelled
+    ///
+    PollingAccessTokenCancelled,
 }
 impl DeviceCodeErrorResponseType {
     fn from_str(s: &str) -> Self {
@@ -189,6 +193,7 @@ impl AsRef<str> for DeviceCodeErrorResponseType {
             DeviceCodeErrorResponseType::AccessDenied => "access_denied",
             DeviceCodeErrorResponseType::ExpiredToken => "expired_token",
             DeviceCodeErrorResponseType::Basic(basic) => basic.as_ref(),
+            DeviceCodeErrorResponseType::PollingAccessTokenCancelled => "polling_cancelled",
         }
     }
 }


### PR DESCRIPTION
There is a usecase in the device code workflow that a user will cancel during login. It is good to also terminate the loop inside request_async function.