### PR TITLE
Use SPDX license format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "oauth2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Florin Lipan <florinlipan@gmail.com>", "David A. Ramos <ramos@cs.stanford.edu>"]
 version = "4.3.1"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "An extensible, strongly-typed implementation of OAuth2"
 repository = "https://github.com/ramosbugs/oauth2-rs"
 edition = "2018"


### PR DESCRIPTION
The use of `/` have been deprecated