### PR TITLE
Fix Microsoft device code example

### DIFF
--- a/examples/microsoft_devicecode.rs
+++ b/examples/microsoft_devicecode.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         None,
         AuthUrl::new("https://login.microsoftonline.com/common/oauth2/v2.0/authorize".to_string())?,
         Some(TokenUrl::new(
-            "https://login.microsoftonline.com/common/v2.0/oauth2/token".to_string(),
+            "https://login.microsoftonline.com/common/oauth2/v2.0/token".to_string(),
         )?),
     )
     .set_device_authorization_url(device_auth_url);


### PR DESCRIPTION
Corrects the url used in microsoft device code example, found this issue during my testing.

Link to relevant [documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code#authenticating-the-user) showing the correct url.