### PR TITLE
Fixing sleep interval compounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2351,6 +2351,8 @@ where
 
             // Sleep here using the provided sleep function.
             sleep_fn(interval);
+            // This will ensure that the interval won't compound by 2 if there is a return error from the http_client.
+            interval = self.dev_auth_resp.interval();
         }
     }
 
@@ -2396,6 +2398,8 @@ where
 
             // Sleep here using the provided sleep function.
             sleep_fn(interval).await;
+            // This will ensure that the interval won't compound by 2 if there is a return error from the http_client.
+            interval = self.dev_auth_resp.interval();
         }
     }
 


### PR DESCRIPTION
It was observe that during polling of token, if an error keeps returning from the http_client, the sleep interval compounds by 2. This scenario can be reproduced if ethernet cable is unplugged for a long time not more than the expiry time.

To reproduced, set up a custom curl http_client with connect_timeout() and timeout() from Easy2 curl-rust crate.