### PR TITLE
Upgrade `base64` to `0.21`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.21"
 thiserror = "1.0"
 http = "0.2"
 rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,6 +427,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
+use base64::prelude::*;
 use chrono::serde::ts_seconds_option;
 use chrono::{DateTime, Utc};
 use http::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
@@ -1998,7 +1999,7 @@ fn endpoint_request<'a>(
             let urlencoded_secret: String =
                 form_urlencoded::byte_serialize(secret.secret().as_bytes()).collect();
             let b64_credential =
-                base64::encode(&format!("{}:{}", &urlencoded_id, urlencoded_secret));
+                BASE64_STANDARD.encode(&format!("{}:{}", &urlencoded_id, urlencoded_secret));
             headers.append(
                 AUTHORIZATION,
                 HeaderValue::from_str(&format!("Basic {}", &b64_credential)).unwrap(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,6 +3,7 @@ use std::fmt::Error as FormatterError;
 use std::fmt::{Debug, Formatter};
 use std::ops::Deref;
 
+use base64::prelude::*;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -481,10 +482,7 @@ impl PkceCodeChallenge {
         // This implies 32-96 octets of random data to be base64 encoded.
         assert!(num_bytes >= 32 && num_bytes <= 96);
         let random_bytes: Vec<u8> = (0..num_bytes).map(|_| thread_rng().gen::<u8>()).collect();
-        PkceCodeVerifier::new(base64::encode_config(
-            &random_bytes,
-            base64::URL_SAFE_NO_PAD,
-        ))
+        PkceCodeVerifier::new(BASE64_URL_SAFE_NO_PAD.encode(&random_bytes))
     }
 
     ///
@@ -501,7 +499,7 @@ impl PkceCodeChallenge {
         assert!(code_verifier.secret().len() >= 43 && code_verifier.secret().len() <= 128);
 
         let digest = Sha256::digest(code_verifier.secret().as_bytes());
-        let code_challenge = base64::encode_config(&digest, base64::URL_SAFE_NO_PAD);
+        let code_challenge = BASE64_URL_SAFE_NO_PAD.encode(digest);
 
         Self {
             code_challenge,
@@ -597,7 +595,7 @@ new_secret_type![
         ///
         pub fn new_random_len(num_bytes: u32) -> Self {
             let random_bytes: Vec<u8> = (0..num_bytes).map(|_| thread_rng().gen::<u8>()).collect();
-            CsrfToken::new(base64::encode_config(&random_bytes, base64::URL_SAFE_NO_PAD))
+            CsrfToken::new(BASE64_URL_SAFE_NO_PAD.encode(random_bytes))
         }
     }
 ];


### PR DESCRIPTION
A new trait-based system has been employed, with implementations for all the configurations rather than those configurations being passed as argument to the free `encode_config()` function.
