### PR TITLE
feat: Derive hash and eq for state

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -579,7 +579,7 @@ new_secret_type![
     /// via the `state` parameter.
     ///
     #[must_use]
-    #[derive(Clone, Deserialize, Serialize)]
+    #[derive(Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
     CsrfToken(String)
     impl {
         ///


### PR DESCRIPTION
Deriving traits necessary for storing CsrfToken in HashMap / HashSet - like structures for easier implementation of state store without a need to access the wrapped secret directly.