### PR TITLE
implementing feature for PartialEq and Hash with comparison of Sha256 hashed values for secrets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = ["reqwest", "rustls-tls"]
 pkce-plain = []
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+timing-resistant-secret-traits = []
 
 [dependencies]
 base64 = "0.13"

--- a/src/types.rs
+++ b/src/types.rs
@@ -579,7 +579,7 @@ new_secret_type![
     /// via the `state` parameter.
     ///
     #[must_use]
-    #[derive(Clone, Deserialize, Serialize)]
+    #[derive(Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
     CsrfToken(String)
     impl {
         ///


### PR DESCRIPTION
following advice in
https://github.com/ramosbugs/oauth2-rs/issues/107#issuecomment-649834938
added a feature that allows safer comparisons of secret values that should be resistant to timing attacks.