### PR TITLE
reqwest: Migrate to shared `Error` type and use `thiserror`'s `From` impl

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2616,5 +2616,5 @@ fn test_send_sync_impl() {
     #[cfg(feature = "curl")]
     is_sync_and_send::<super::curl::Error>();
     #[cfg(feature = "reqwest")]
-    is_sync_and_send::<super::reqwest::Error<TestError>>();
+    is_sync_and_send::<super::reqwest::Error>();
 }


### PR DESCRIPTION
`reqwest` no longer has a separate error type for sync and async implementations.  In addition `thiserror` can generate `From` implementations for automatic conversions in the `Try` (`?`) operator.

Finally, delete some unnecessary `#[cfg]` wraps that are already guarding the module as a whole, and that the code won't compile without anyway.
