### PR TITLE
Fix comments about csrf_state

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@
 //!
 //! // Once the user has been redirected to the redirect URL, you'll have access to the
 //! // authorization code. For security reasons, your code should verify that the `state`
-//! // parameter returned by the server matches `csrf_state`.
+//! // parameter returned by the server matches `csrf_token.secret()`.
 //!
 //! // Now you can trade it for an access token.
 //! let token_result =
@@ -202,7 +202,7 @@
 //!
 //! // Once the user has been redirected to the redirect URL, you'll have access to the
 //! // authorization code. For security reasons, your code should verify that the `state`
-//! // parameter returned by the server matches `csrf_state`.
+//! // parameter returned by the server matches `csrf_token.secret()`.
 //!
 //! // Now you can trade it for an access token.
 //! let token_result = client
@@ -259,7 +259,7 @@
 //!
 //! // Once the user has been redirected to the redirect URL, you'll have the access code.
 //! // For security reasons, your code should verify that the `state` parameter returned by the
-//! // server matches `csrf_state`.
+//! // server matches `csrf_token.secret()`.
 //!
 //! # Ok(())
 //! # }

--- a/src/types.rs
+++ b/src/types.rs
@@ -594,7 +594,7 @@ new_secret_type![
 new_secret_type![
     ///
     /// Value used for [CSRF](https://tools.ietf.org/html/rfc6749#section-10.12) protection
-    /// via the `state` parameter.
+    /// via the `state` parameter. Compare the `state` parameter to `self.secret()`.
     ///
     #[must_use]
     #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
Clarify that the `state` parameter should be compared to the `csrf_token.secret()`.

Fixes #208.