### PR TITLE
feat(logging): instrument tracing into http clients

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ ureq = { version = "2", optional = true }
 url = { version = "2.1", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std", "wasmbind"] }
 serde_path_to_error = "0.1.2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "parking_lot"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -48,3 +50,4 @@ uuid = { version = "0.8", features = ["v4"] }
 anyhow = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 async-std = "1.6.3"
+test-log = { version = "0.2.8", default-features = false, features = ["trace"] }

--- a/src/curl.rs
+++ b/src/curl.rs
@@ -26,6 +26,7 @@ pub enum Error {
 ///
 /// Synchronous HTTP client.
 ///
+#[tracing::instrument]
 pub fn http_client(request: HttpRequest) -> Result<HttpResponse, Error> {
     let mut easy = Easy::new();
     easy.url(&request.url.to_string()[..])?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1318,6 +1318,7 @@ where
     ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub fn request<F, RE>(self, http_client: F) -> Result<TR, RequestTokenError<RE, TE>>
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
@@ -1329,6 +1330,7 @@ where
     ///
     /// Asynchronously sends the request to the authorization server and returns a Future.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub async fn request_async<C, F, RE>(
         self,
         http_client: C,
@@ -1417,6 +1419,7 @@ where
     ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub fn request<F, RE>(self, http_client: F) -> Result<TR, RequestTokenError<RE, TE>>
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
@@ -1427,6 +1430,7 @@ where
     ///
     /// Asynchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub async fn request_async<C, F, RE>(
         self,
         http_client: C,
@@ -1537,6 +1541,7 @@ where
     ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub fn request<F, RE>(self, http_client: F) -> Result<TR, RequestTokenError<RE, TE>>
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
@@ -1548,6 +1553,7 @@ where
     ///
     /// Asynchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub async fn request_async<C, F, RE>(
         self,
         http_client: C,
@@ -1657,6 +1663,7 @@ where
     ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub fn request<F, RE>(self, http_client: F) -> Result<TR, RequestTokenError<RE, TE>>
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
@@ -1668,6 +1675,7 @@ where
     ///
     /// Asynchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub async fn request_async<C, F, RE>(
         self,
         http_client: C,
@@ -1803,6 +1811,7 @@ where
     ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub fn request<F, RE>(self, http_client: F) -> Result<TIR, RequestTokenError<RE, TE>>
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
@@ -1814,6 +1823,7 @@ where
     ///
     /// Asynchronously sends the request to the authorization server and returns a Future.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub async fn request_async<C, F, RE>(
         self,
         http_client: C,
@@ -1909,6 +1919,7 @@ where
     /// Error [`UnsupportedTokenType`](crate::revocation::RevocationErrorResponseType::UnsupportedTokenType) will be returned if the
     /// type of token type given is not supported by the server.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub fn request<F, RE>(self, http_client: F) -> Result<(), RequestTokenError<RE, TE>>
     where
         F: FnOnce(HttpRequest) -> Result<HttpResponse, RE>,
@@ -1923,6 +1934,7 @@ where
     ///
     /// Asynchronously sends the request to the authorization server and returns a Future.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub async fn request_async<C, F, RE>(
         self,
         http_client: C,
@@ -2027,6 +2039,7 @@ fn endpoint_request<'a>(
     }
 }
 
+#[tracing::instrument(err)]
 fn endpoint_response<RE, TE, DO>(
     http_response: HttpResponse,
 ) -> Result<DO, RequestTokenError<RE, TE>>
@@ -2054,6 +2067,7 @@ where
     check_response_status(&http_response)
 }
 
+#[tracing::instrument(err)]
 fn check_response_status<RE, TE>(
     http_response: &HttpResponse,
 ) -> Result<(), RequestTokenError<RE, TE>>
@@ -2081,6 +2095,7 @@ where
     Ok(())
 }
 
+#[tracing::instrument(err)]
 fn check_response_body<RE, TE>(
     http_response: &HttpResponse,
 ) -> Result<(), RequestTokenError<RE, TE>>
@@ -2205,6 +2220,7 @@ where
     ///
     /// Synchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub fn request<F, RE, EF>(
         self,
         http_client: F,
@@ -2220,6 +2236,7 @@ where
     ///
     /// Asynchronously sends the request to the authorization server and returns a Future.
     ///
+    #[tracing::instrument(err, skip(self, http_client))]
     pub async fn request_async<C, F, RE, EF>(
         self,
         http_client: C,
@@ -2315,6 +2332,7 @@ where
     /// Synchronously polls the authorization server for a response, waiting
     /// using a user defined sleep function.
     ///
+    #[tracing::instrument(err, skip(self, http_client, sleep_fn))]
     pub fn request<F, S, RE>(
         self,
         http_client: F,
@@ -2358,6 +2376,7 @@ where
     ///
     /// Asynchronously sends the request to the authorization server and awaits a response.
     ///
+    #[tracing::instrument(err, skip(self, http_client, sleep_fn))]
     pub async fn request_async<C, F, S, SF, RE>(
         self,
         http_client: C,

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -36,6 +36,7 @@ mod blocking {
     ///
     /// Synchronous HTTP client.
     ///
+    #[tracing::instrument]
     pub fn http_client(request: HttpRequest) -> Result<HttpResponse, Error> {
         let client = blocking::Client::builder()
             // Following redirects opens the client up to SSRF vulnerabilities.
@@ -71,6 +72,7 @@ mod async_client {
     ///
     /// Asynchronous HTTP client.
     ///
+    #[tracing::instrument]
     pub async fn async_http_client(request: HttpRequest) -> Result<HttpResponse, Error> {
         let client = {
             let builder = reqwest::Client::builder();
@@ -82,6 +84,12 @@ mod async_client {
 
             builder.build()?
         };
+
+
+        match std::str::from_utf8(request.body.as_slice()) {
+            Ok(request_body) => tracing::debug!(%request_body, "request body"),
+            Err(e) => tracing::debug!("request body is not valid utf-8: {}", e),
+        }
 
         let mut request_builder = client
             .request(request.method, request.url.as_str())

--- a/src/types.rs
+++ b/src/types.rs
@@ -497,10 +497,10 @@ impl PkceCodeChallenge {
         // The RFC specifies that the code verifier must have "a minimum length of 43
         // characters and a maximum length of 128 characters".
         // This implies 32-96 octets of random data to be base64 encoded.
-        assert!(num_bytes >= 32 && num_bytes <= 96);
+        assert!((32..=96).contains(&num_bytes));
         let random_bytes: Vec<u8> = (0..num_bytes).map(|_| thread_rng().gen::<u8>()).collect();
         PkceCodeVerifier::new(base64::encode_config(
-            &random_bytes,
+            random_bytes,
             base64::URL_SAFE_NO_PAD,
         ))
     }
@@ -519,7 +519,7 @@ impl PkceCodeChallenge {
         assert!(code_verifier.secret().len() >= 43 && code_verifier.secret().len() <= 128);
 
         let digest = Sha256::digest(code_verifier.secret().as_bytes());
-        let code_challenge = base64::encode_config(&digest, base64::URL_SAFE_NO_PAD);
+        let code_challenge = base64::encode_config(digest, base64::URL_SAFE_NO_PAD);
 
         Self {
             code_challenge,
@@ -615,7 +615,7 @@ new_secret_type![
         ///
         pub fn new_random_len(num_bytes: u32) -> Self {
             let random_bytes: Vec<u8> = (0..num_bytes).map(|_| thread_rng().gen::<u8>()).collect();
-            CsrfToken::new(base64::encode_config(&random_bytes, base64::URL_SAFE_NO_PAD))
+            CsrfToken::new(base64::encode_config(random_bytes, base64::URL_SAFE_NO_PAD))
         }
     }
 ];

--- a/src/ureq.rs
+++ b/src/ureq.rs
@@ -29,6 +29,7 @@ pub enum Error {
 ///
 /// Synchronous HTTP client for ureq.
 ///
+#[tracing::instrument]
 pub fn http_client(request: HttpRequest) -> Result<HttpResponse, Error> {
     let mut req = if request.method == Method::POST {
         ureq::post(request.url.as_ref())


### PR DESCRIPTION
This commit adds logging for consuming crates which enable and opt-in to tracing. These logs are configurable via the usual means, but can be tuned if other details are necessary or should be excluded.

Perhaps some of the request and response details should be omitted, however I have had difficulty troubleshooting my SSO integrations as the oauth2 library only returns "Server returned an error response" rather than the actual response details such as `"invalid_grant"` with related details. The HTTP response is printed out in a Vec<u8> and has to be converted to ASCII manually, but this at least opens the possibility for further debugging in-code.