### PR TITLE
Fix: add Send + Sync to AsyncHttpClient

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -28,12 +28,12 @@ pub trait AsyncHttpClient<'c> {
     fn call(
         &'c self,
         request: HttpRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + 'c>>;
+    ) -> Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + 'c + Send + Sync>>;
 }
 impl<'c, E, F, T> AsyncHttpClient<'c> for T
 where
     E: Error + 'static,
-    F: Future<Output = Result<HttpResponse, E>> + 'c,
+    F: Future<Output = Result<HttpResponse, E>> + 'c + Send + Sync,
     // We can't implement this for FnOnce because the device authorization flow requires clients to
     // supportmultiple calls.
     T: Fn(HttpRequest) -> F,
@@ -43,7 +43,7 @@ where
     fn call(
         &'c self,
         request: HttpRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + 'c>> {
+    ) -> Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + 'c + Send + Sync>> {
         Box::pin(self(request))
     }
 }

--- a/src/reqwest_client.rs
+++ b/src/reqwest_client.rs
@@ -9,7 +9,7 @@ impl<'c> AsyncHttpClient<'c> for reqwest::Client {
     fn call(
         &'c self,
         request: HttpRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + 'c>> {
+    ) -> Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + 'c + Send + Sync>> {
         Box::pin(async move {
             let response = self
                 .execute(request.try_into().map_err(Box::new)?)


### PR DESCRIPTION
Fix the error of Future not send and not safe to pass across threads.