### PR TITLE
only include the chrono wasmbind feature in wasm arch's

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,11 +58,14 @@ serde_json = "1.0"
 sha2 = "0.10"
 ureq = { version = "2", optional = true }
 url = { version = "2.1", features = ["serde"] }
-chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std", "wasmbind"] }
+chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std"] }
 serde_path_to_error = "0.1.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.chrono]
+features = ["wasmbind"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 curl = { version = "0.4.0", optional = true }


### PR DESCRIPTION
I looked at the Cargo.lock of my api, and found that wasm-bindgen was included because of the chrono dependency of this crate, so thought I would remove it from default