### PR TITLE
Derive clone for EndpointState types

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -35,6 +35,7 @@ impl private::EndpointStateSealed for EndpointSet {}
 
 /// [Typestate](https://cliffle.com/blog/rust-typestate/) indicating that an endpoint may have been
 /// set and can be used via fallible methods.
+#[derive(Clone)]
 pub struct EndpointMaybeSet;
 impl EndpointState for EndpointMaybeSet {}
 impl private::EndpointStateSealed for EndpointMaybeSet {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,12 +21,14 @@ pub trait EndpointState: private::EndpointStateSealed {}
 
 /// [Typestate](https://cliffle.com/blog/rust-typestate/) indicating that an endpoint has not been
 /// set and cannot be used.
+#[derive(Clone)]
 pub struct EndpointNotSet;
 impl EndpointState for EndpointNotSet {}
 impl private::EndpointStateSealed for EndpointNotSet {}
 
 /// [Typestate](https://cliffle.com/blog/rust-typestate/) indicating that an endpoint has been set
 /// and is ready to be used.
+#[derive(Clone)]
 pub struct EndpointSet;
 impl EndpointState for EndpointSet {}
 impl private::EndpointStateSealed for EndpointSet {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,21 +21,21 @@ pub trait EndpointState: private::EndpointStateSealed {}
 
 /// [Typestate](https://cliffle.com/blog/rust-typestate/) indicating that an endpoint has not been
 /// set and cannot be used.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EndpointNotSet;
 impl EndpointState for EndpointNotSet {}
 impl private::EndpointStateSealed for EndpointNotSet {}
 
 /// [Typestate](https://cliffle.com/blog/rust-typestate/) indicating that an endpoint has been set
 /// and is ready to be used.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EndpointSet;
 impl EndpointState for EndpointSet {}
 impl private::EndpointStateSealed for EndpointSet {}
 
 /// [Typestate](https://cliffle.com/blog/rust-typestate/) indicating that an endpoint may have been
 /// set and can be used via fallible methods.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EndpointMaybeSet;
 impl EndpointState for EndpointMaybeSet {}
 impl private::EndpointStateSealed for EndpointMaybeSet {}


### PR DESCRIPTION
Currently,  Client cannot properly derive clone, because none of the EndpointState types implement clone. For example, trying to use openidconnect's CoreClient in a context that requires it to be Clone produces the following error:

> the trait bound `openidconnect::EndpointSet: Clone` is not satisfied
> required for `Client<EmptyAdditionalClaims, ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ...>` to implement `Clone`