### PR TITLE
Allow OAuth2 server to return 200 OK or 201 Created HTTP status codes.

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -188,7 +188,9 @@ where
     RE: Error + 'static,
     TE: ErrorResponse,
 {
-    if http_response.status() != StatusCode::OK {
+    if [StatusCode::OK, StatusCode::CREATED].contains(&http_response.status()) {
+        Ok(())
+    } else {
         let reason = http_response.body().as_slice();
         if reason.is_empty() {
             Err(RequestTokenError::Other(
@@ -203,8 +205,6 @@ where
             };
             Err(error)
         }
-    } else {
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Some OAuth2 auth servers will return a `201 Created` status code instead of `200 OK` for client credential exchanges, denoting a new access token has been created. This is a simple upgrade to expand oauth2-rs's auth server support.