### PR TITLE
feat: inline format args

### DIFF
--- a/examples/github.rs
+++ b/examples/github.rs
@@ -115,7 +115,7 @@ fn main() {
     // Exchange the code with a token.
     let token_res = client.exchange_code(code).request(&http_client);
 
-    println!("Github returned the following token:\n{:?}\n", token_res);
+    println!("Github returned the following token:\n{token_res:?}\n");
 
     if let Ok(token) = token_res {
         // NB: Github returns a single comma-separated "scope" parameter instead of multiple
@@ -130,6 +130,6 @@ fn main() {
         } else {
             Vec::new()
         };
-        println!("Github returned the following scopes:\n{:?}\n", scopes);
+        println!("Github returned the following scopes:\n{scopes:?}\n");
     }
 }

--- a/examples/github_async.rs
+++ b/examples/github_async.rs
@@ -116,7 +116,7 @@ async fn main() {
     // Exchange the code with a token.
     let token_res = client.exchange_code(code).request_async(&http_client).await;
 
-    println!("Github returned the following token:\n{:?}\n", token_res);
+    println!("Github returned the following token:\n{token_res:?}\n");
 
     if let Ok(token) = token_res {
         // NB: Github returns a single comma-separated "scope" parameter instead of multiple
@@ -131,6 +131,6 @@ async fn main() {
         } else {
             Vec::new()
         };
-        println!("Github returned the following scopes:\n{:?}\n", scopes);
+        println!("Github returned the following scopes:\n{scopes:?}\n");
     }
 }

--- a/examples/google.rs
+++ b/examples/google.rs
@@ -132,10 +132,7 @@ fn main() {
         .set_pkce_verifier(pkce_code_verifier)
         .request(&http_client);
 
-    println!(
-        "Google returned the following token:\n{:?}\n",
-        token_response
-    );
+    println!("Google returned the following token:\n{token_response:?}\n");
 
     // Revoke the obtained token
     let token_response = token_response.unwrap();

--- a/examples/google_devicecode.rs
+++ b/examples/google_devicecode.rs
@@ -83,5 +83,5 @@ fn main() {
         .request(&http_client, std::thread::sleep, None)
         .expect("Failed to get token");
 
-    println!("Google returned the following token:\n{:?}\n", token);
+    println!("Google returned the following token:\n{token:?}\n");
 }

--- a/examples/letterboxd.rs
+++ b/examples/letterboxd.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), anyhow::Error> {
         .exchange_password(&letterboxd_username, &letterboxd_password)
         .request(&|request| http_client.execute(request))?;
 
-    println!("{:?}", token_result);
+    println!("{token_result:?}");
 
     Ok(())
 }

--- a/examples/microsoft_devicecode_common_user.rs
+++ b/examples/microsoft_devicecode_common_user.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .request_async(&http_client, tokio::time::sleep, None)
         .await;
 
-    eprintln!("Token:{:?}", token_result);
+    eprintln!("Token:{token_result:?}");
 
     Ok(())
 }

--- a/examples/microsoft_devicecode_tenant_user.rs
+++ b/examples/microsoft_devicecode_tenant_user.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .request_async(&http_client, tokio::time::sleep, None)
         .await;
 
-    eprintln!("Token:{:?}", token_result);
+    eprintln!("Token:{token_result:?}");
 
     Ok(())
 }

--- a/examples/msgraph.rs
+++ b/examples/msgraph.rs
@@ -138,5 +138,5 @@ fn main() {
         .set_pkce_verifier(pkce_code_verifier)
         .request(&http_client);
 
-    println!("MS Graph returned the following token:\n{:?}\n", token);
+    println!("MS Graph returned the following token:\n{token:?}\n");
 }

--- a/examples/wunderlist.rs
+++ b/examples/wunderlist.rs
@@ -222,8 +222,5 @@ fn main() {
         .add_extra_param("client_secret", client_secret_str)
         .request(&http_client);
 
-    println!(
-        "Wunderlist returned the following token:\n{:?}\n",
-        token_res
-    );
+    println!("Wunderlist returned the following token:\n{token_res:?}\n");
 }

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -693,10 +693,9 @@ mod tests {
         \"verification_uri\": \"https://verify/here\", \
         \"user_code\": \"abcde\", \
         \"verification_uri_complete\": \"https://verify/here?abcde\", \
-        \"expires_in\": {}, \
+        \"expires_in\": {expires_in}, \
         \"interval\": 1 \
-        }}",
-            expires_in
+        }}"
         );
 
         let device_auth_url =

--- a/src/devicecode.rs
+++ b/src/devicecode.rs
@@ -455,8 +455,7 @@ where
         let timeout_dur = timeout.unwrap_or_else(|| self.dev_auth_resp.expires_in());
         let chrono_timeout = chrono::Duration::from_std(timeout_dur).map_err(|e| {
             RequestTokenError::Other(format!(
-                "failed to convert `{:?}` to `chrono::Duration`: {}",
-                timeout_dur, e
+                "failed to convert `{timeout_dur:?}` to `chrono::Duration`: {e}"
             ))
         })?;
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -227,9 +227,7 @@ where
         Err(
           RequestTokenError::Other(
             format!(
-              "unexpected response Content-Type: {:?}, should be `{}`",
-              content_type,
-              CONTENT_TYPE_JSON
+              "unexpected response Content-Type: {content_type:?}, should be `{CONTENT_TYPE_JSON}`",
             )
           )
         )

--- a/src/error.rs
+++ b/src/error.rs
@@ -103,7 +103,7 @@ where
             formatted.push(')');
         }
 
-        write!(f, "{}", formatted)
+        write!(f, "{formatted}")
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -150,7 +150,7 @@ pub(crate) mod colorful_extension {
         fn fmt(&self, f: &mut Formatter) -> Result<(), FormatterError> {
             let message: &str = self.to_str();
 
-            write!(f, "{}", message)
+            write!(f, "{message}")
         }
     }
 

--- a/src/token/tests.rs
+++ b/src/token/tests.rs
@@ -707,12 +707,12 @@ fn test_exchange_code_with_simple_json_error() {
             assert_eq!(
                 "StandardErrorResponse { error: invalid_request, \
                  error_description: Some(\"stuff happened\"), error_uri: None }",
-                format!("{:?}", error_response)
+                format!("{error_response:?}")
             );
             // Test Display trait for ErrorResponse
             assert_eq!(
                 "invalid_request: stuff happened",
-                format!("{}", error_response)
+                format!("{error_response}")
             );
 
             // Test Debug trait for BasicErrorResponseType
@@ -732,14 +732,14 @@ fn test_exchange_code_with_simple_json_error() {
                 serde_json::from_str::<BasicErrorResponse>(&serialized_json).unwrap();
             assert_eq!(error_response, &deserialized_error);
         }
-        other => panic!("Unexpected error: {:?}", other),
+        other => panic!("Unexpected error: {other:?}"),
     }
 
     // Test Debug trait for RequestTokenError
     assert_eq!(
         "ServerResponse(StandardErrorResponse { error: invalid_request, \
          error_description: Some(\"stuff happened\"), error_uri: None })",
-        format!("{:?}", token_err)
+        format!("{token_err:?}")
     );
     // Test Display trait for RequestTokenError
     assert_eq!(
@@ -783,7 +783,7 @@ fn test_exchange_code_with_json_parse_error() {
                 json_err.inner().classify()
             );
         }
-        other => panic!("Unexpected error: {:?}", other),
+        other => panic!("Unexpected error: {other:?}"),
     }
 }
 
@@ -816,7 +816,7 @@ fn test_exchange_code_with_unexpected_content_type() {
                 error_str
             );
         }
-        other => panic!("Unexpected error: {:?}", other),
+        other => panic!("Unexpected error: {other:?}"),
     }
 }
 
@@ -860,7 +860,7 @@ fn test_exchange_code_with_invalid_token_type() {
                 json_err.inner().classify()
             );
         }
-        other => panic!("Unexpected error: {:?}", other),
+        other => panic!("Unexpected error: {other:?}"),
     }
 }
 
@@ -902,7 +902,7 @@ fn test_exchange_code_with_400_status_code() {
             );
             assert_eq!(None, error_response.error_uri());
         }
-        other => panic!("Unexpected error: {:?}", other),
+        other => panic!("Unexpected error: {other:?}"),
     }
 
     assert_eq!(
@@ -926,7 +926,7 @@ fn test_exchange_code_fails_gracefully_on_transport_error() {
 
     match token.err().unwrap() {
         RequestTokenError::Request(FakeError::Err) => (),
-        other => panic!("Unexpected error: {:?}", other),
+        other => panic!("Unexpected error: {other:?}"),
     }
 }
 
@@ -1111,14 +1111,14 @@ fn test_extension_with_simple_json_error() {
             .unwrap();
             assert_eq!(error_response, &deserialized_error);
         }
-        other => panic!("Unexpected error: {:?}", other),
+        other => panic!("Unexpected error: {other:?}"),
     }
 
     // Test Debug trait for RequestTokenError
     assert_eq!(
         "ServerResponse(StandardErrorResponse { error: too_light, \
          error_description: Some(\"stuff happened\"), error_uri: Some(\"https://errors\") })",
-        format!("{:?}", token_err)
+        format!("{token_err:?}")
     );
     // Test Display trait for RequestTokenError
     assert_eq!(
@@ -1210,7 +1210,7 @@ fn test_extension_with_custom_json_error() {
         RequestTokenError::ServerResponse(e) => {
             assert_eq!("non-compliant oauth implementation ;-)", e.custom_error)
         }
-        e => panic!("failed to correctly parse custom server error, got {:?}", e),
+        e => panic!("failed to correctly parse custom server error, got {e:?}"),
     };
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -611,7 +611,7 @@ mod tests {
     #[test]
     fn test_secret_redaction() {
         let secret = ClientSecret::new("top_secret".to_string());
-        assert_eq!("ClientSecret([redacted])", format!("{:?}", secret));
+        assert_eq!("ClientSecret([redacted])", format!("{secret:?}"));
     }
 
     #[test]


### PR DESCRIPTION
Since the MSRV of 5.x will be `1.65`, [inline format args](https://github.com/rust-lang/rust/pull/90473/) were added in `1.58`, this PR replaces every possible encounter of this.
This PR comes with better code readability (marginally and only in some occasions at least) and no disadvantages.