### PR TITLE
Make `AsyncHttpClient::Future` `Send` on non-wasm archs

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -25,7 +25,12 @@ pub trait AsyncHttpClient<'c> {
     type Error: Error + 'static;
 
     /// Future type returned by HTTP client.
+    #[cfg(target_arch = "wasm32")]
     type Future: Future<Output = Result<HttpResponse, Self::Error>> + 'c;
+
+    /// Future type returned by HTTP client.
+    #[cfg(not(target_arch = "wasm32"))]
+    type Future: Future<Output = Result<HttpResponse, Self::Error>> + Send + 'c;
 
     /// Perform a single HTTP request.
     fn call(&'c self, request: HttpRequest) -> Self::Future;
@@ -33,7 +38,7 @@ pub trait AsyncHttpClient<'c> {
 impl<'c, E, F, T> AsyncHttpClient<'c> for T
 where
     E: Error + 'static,
-    F: Future<Output = Result<HttpResponse, E>> + 'c,
+    F: Future<Output = Result<HttpResponse, E>> + Send + 'c,
     // We can't implement this for FnOnce because the device authorization flow requires clients to
     // supportmultiple calls.
     T: Fn(HttpRequest) -> F,


### PR DESCRIPTION
This is useful for adding some `Send` bounds on other methods in the dependent `openidconnect-rs` crate ([here](https://github.com/poljar/openidconnect-rs/commit/c7e1dc31b83dd7559125984bfd36b9c0f191585e)). Since there was a `cfg` guard for wasm in the reqwest_client implementation, I also included it here, so that wasm doesn't require the bound itself.