### PR TITLE
Update to ureq 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ reqwest = { version = "0.12", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-ureq = { version = "2", optional = true }
+ureq = { version = "3", optional = true }
 url = { version = "2.1", features = ["serde"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std", "wasmbind"] }
 serde_path_to_error = "0.1.2"


### PR DESCRIPTION
Simple update to ureq version 3, no changes required except for `Cargo.toml`