### PR TITLE
fix: h3 compat Sync trait

### DIFF
--- a/src/reqwest_client.rs
+++ b/src/reqwest_client.rs
@@ -10,7 +10,7 @@ impl<'c> AsyncHttpClient<'c> for reqwest::Client {
     type Future = Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + 'c>>;
     #[cfg(not(target_arch = "wasm32"))]
     type Future =
-        Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + Send + Sync + 'c>>;
+        Pin<Box<dyn Future<Output = Result<HttpResponse, Self::Error>> + Send + 'c>>;
 
     fn call(&'c self, request: HttpRequest) -> Self::Future {
         Box::pin(async move {


### PR DESCRIPTION
Fixes: https://github.com/ramosbugs/oauth2-rs/issues/299

reqwest client future does not need to be Sync.