### PR TITLE
PkceCodeChallenge::new wrap an existing challenge

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -431,6 +431,14 @@ pub struct PkceCodeChallenge {
     code_challenge_method: PkceCodeChallengeMethod,
 }
 impl PkceCodeChallenge {
+    /// Create a new PkceCodeChallenge to wrap the given String challenge and method
+    pub fn new(code_challenge: String, code_challenge_method: PkceCodeChallengeMethod) -> Self {
+        PkceCodeChallenge {
+            code_challenge,
+            code_challenge_method,
+        }
+    }
+
     /// Generate a new random, base64-encoded SHA-256 PKCE code.
     pub fn new_random_sha256() -> (Self, PkceCodeVerifier) {
         Self::new_random_sha256_len(32)


### PR DESCRIPTION
Add the ability to wrap an existing challenge.

I realize it was probably a conscious choice not to implement it as mentioned in this other comment:

> This type intentionally does not implement Clone in order to make it difficult to reuse PKCE challenges

But at the same time I'm using server side OpenIDConnect authorization code flow with `client_id` and `client_secret` and I would like to be able to use pkce too and pass the challenge created by the client.


Edit: Realized afterward that I could just use `add_extra_param` but I think it would be cleaner to allow to build the `PkceCodeChallenge`.