### PR TITLE
accept Microsoft's token responses by default

### DIFF
--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -605,6 +605,10 @@ where
     #[serde(deserialize_with = "crate::helpers::deserialize_untagged_enum_case_insensitive")]
     token_type: TT,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// The lifetime in seconds of the access token. Should be an integer according to the RFC,
+    /// but some providers such as Azure AD return a string.
+    #[serde(default)]
+    #[serde(deserialize_with = "crate::helpers::deserialize_optional_u64_or_string")]
     expires_in: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     refresh_token: Option<RefreshToken>,


### PR DESCRIPTION
add support for string-encoded `expires_in` for Azure AD compatibility

While [RFC 6749 Section 5.1](https://tools.ietf.org/html/rfc6749#section-5.1) describes `expires_in` as an integer, Microsoft Azure AD returns this value as a string (e.g., `"3600"` instead of `3600`). This non-compliant behavior has been a [known issue since at least 2022](https://feedback.azure.com/d365community/idea/7772fd95-26e6-ec11-a81b-0022484ee92d), yet remains unresolved.

Given that Microsoft Azure AD is one of the largest OAuth 2.0 identity providers globally, rejecting their token responses due to this technical violation creates a barrier to adoption. Many enterprise applications depend on Azure AD for authentication, making this workaround necessary for real-world compatibility.

This change implements a lenient deserializer that accepts both the standard integer format and Azure's string format, ensuring the library works with RFC-compliant providers while maintaining compatibility with Azure. The fix is transparent to users - existing code continues to work without modification - and adds test coverage for both formats.

fixes https://github.com/ramosbugs/oauth2-rs/issues/191
