### PR TITLE
Add `ureq` v3 support behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 ureq = { version = "2", optional = true }
+ureq_3 = { package = "ureq", version = "3", optional = true }
 url = { version = "2.1", features = ["serde"] }
 chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std", "wasmbind"] }
 serde_path_to_error = "0.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,9 @@ mod types;
 #[cfg(feature = "ureq")]
 mod ureq_client;
 
+#[cfg(feature = "ureq_3")]
+mod ureq_3_client;
+
 pub use crate::client::{Client, EndpointMaybeSet, EndpointNotSet, EndpointSet, EndpointState};
 pub use crate::code::AuthorizationRequest;
 #[cfg(all(feature = "curl", not(target_arch = "wasm32")))]
@@ -561,6 +564,9 @@ pub use ::reqwest;
 
 #[cfg(feature = "ureq")]
 pub use ::ureq;
+
+#[cfg(feature = "ureq_3")]
+pub use ::ureq_3;
 
 const CONTENT_TYPE_JSON: &str = "application/json";
 const CONTENT_TYPE_FORMENCODED: &str = "application/x-www-form-urlencoded";

--- a/src/ureq_3_client.rs
+++ b/src/ureq_3_client.rs
@@ -1,0 +1,17 @@
+use std::io::Read;
+
+use crate::{HttpClientError, HttpRequest, HttpResponse};
+
+impl crate::SyncHttpClient for ureq_3::Agent {
+    type Error = HttpClientError<ureq_3::Error>;
+
+    fn call(&self, request: HttpRequest) -> Result<HttpResponse, Self::Error> {
+        let response = self.run(request).map_err(Box::new)?;
+
+        let (parts, body) = response.into_parts();
+        let mut body_vec = Vec::new();
+        body.into_reader().read_to_end(&mut body_vec)?;
+
+        Ok(HttpResponse::from_parts(parts, body_vec))
+    }
+}


### PR DESCRIPTION
**NOTE**: this is a copy of #332, which now attempts to merge from my `ureq_3` branch instead of `main`.

Fixes https://github.com/ramosbugs/oauth2-rs/issues/315. Closes https://github.com/ramosbugs/oauth2-rs/pull/307, closes https://github.com/ramosbugs/oauth2-rs/pull/324.

Adds ureq version 3 support behind the ureq_3 feature, thus ensuring oauth2-rs v5 is backwards-compatible.