### PR TITLE
docs: fix comment on msgraph requirements

### DIFF
--- a/oauth2/examples/msgraph.rs
+++ b/oauth2/examples/msgraph.rs
@@ -52,7 +52,7 @@ fn main() {
         .set_client_secret(graph_client_secret)
         .set_auth_uri(auth_url)
         .set_token_uri(token_url)
-        // Microsoft Graph requires client_id and client_secret in URL rather than
+        // Microsoft Graph requires client_id and client_secret in request body rather than
         // using Basic authentication.
         .set_auth_type(AuthType::RequestBody)
         // This example will be running its own server at localhost:3003.


### PR DESCRIPTION
The example on Microsoft Graph stated that the client id and client secret should be provided in the URL, which surprised me. 

I double checked to be sure in the [documentation](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-access-token-with-a-client_secret), and the actual requirement is that the client has to provide the client id and client secret in the request body when exchanging the authorization code for an access token. 

