### PR TITLE
Only enable wasmbind feature of chrono on wasm32 target

### DIFF
--- a/oauth2/Cargo.toml
+++ b/oauth2/Cargo.toml
@@ -58,14 +58,15 @@ serde_json = "1.0"
 sha2 = "0.10"
 ureq = { version = "2", optional = true }
 url = { version = "2.1", features = ["serde"] }
-chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std", "wasmbind"] }
 serde_path_to_error = "0.1.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std", "wasmbind"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 curl = { version = "0.4.0", optional = true }
+chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde", "std"] }
 
 [dev-dependencies]
 hex = "0.4"


### PR DESCRIPTION
I'm currently trying to package [clifton](https://clifton.readthedocs.io/stable/), an authentication manager used by my university's supercomputing system, for Fedora. The Fedora package for chrono doesn't enable the wasmbind feature, understandably, since the repos will never build for wasm. 

Packaging clifton requires packaging oauth2-rs, as it is preferred Fedora policy to independently package crates rather than vendor them, but oauth2 requiring chrono's wasmbind feature clashes with the Fedora package's flags. 

It doesn't seem like there's much reason for enabling wasmbind as a feature when we're not targeting WebAssembly, so I believe we can make this conditional. 

What's the pathway for testing WebAssembly code? All unit tests pass for my target (x86_64 Linux), but I'm not sure how to test the unit tests for a WebAssembly target (I can't imagine they'd fail?)